### PR TITLE
feat: richer-view metrics, survival, broader tool coverage, and audit fixes

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,21 +27,10 @@ from people running `assaio` reorders them, and any item can be reshaped or drop
 Theme: a solo user sees their own curve within two weeks of installing. All items read
 existing store columns; none needs a migration.
 
-- [ ] **B01 · turn-efficiency** — S · solo — new validator: one-shot rate (sessions
-  ≤2 turns that still produced edits), median turns per code-producing session,
-  output-tokens-per-turn trend. The most direct "am I getting more per prompt?"
-  signal. Caveat: task size is invisible — directional only.
-- [ ] **B02 · cache-hygiene** — S · both — new validator: cache-read share trend plus
-  cache-write waste (days with high cache writes but little subsequent reading — money
-  spent caching what is never reused). Caveat: vendor cache TTLs are invisible;
-  day-grain approximation.
-- [ ] **B03 · subscription-fit** — S · solo — new validator on top of the existing
-  `config.pricing`: plan utilization, API-equivalent spend vs flat plan cost, the
-  breakeven line ("is Max/Pro paying off, or would API — or the reverse?").
-- [ ] **B04 · coverage-meter** — S · both — new validator: how much of the window is
-  high-confidence data — share of records with activity capture (Claude Code/Codex) vs
-  cost-only (Gemini/Cline/plugins), share priced. The honesty backbone the other
-  metrics lean on.
+- [ ] **B02 · cache-hygiene trend** — S · both — add the day-over-day cache-read-share
+  trend to the shipped `cache-hygiene` validator, which already reports the current-window
+  share and the cache-write-waste flag. Caveat: vendor cache TTLs are invisible; day-grain
+  approximation.
 - [ ] **B05 · statusline** — S · solo — `assaio-agent statusline`: one line (today's
   estimated `$`, tokens, budget remaining) plus a Claude Code statusline integration
   recipe. The daily-visibility habit loop.
@@ -76,8 +65,11 @@ existing store columns; none needs a migration.
   totals as JSON on stdin) and emits alerts with severity; assaio prints, sets exit
   code, or forwards. Config `rules:`, same opt-in and boundary-validation posture as
   ADR 0003/0004.
-- [ ] **B14 · Aider connector** — M · both — in-tree parser (strong local logs);
-  likely the best next source after the current four.
+- [ ] **B14 · Aider connector** — M · both — in-tree parser. The parseable token source is
+  the opt-in `~/.aider/analytics.jsonl` (`message_send` events with `properties.{main_model,
+  prompt_tokens,completion_tokens,total_tokens,cost}`, `time` in epoch seconds, no session
+  id or cache split); `.aider.chat.history.md` is markdown-only. No structured per-edit field
+  — Aider auto-commits, so lines +/- come from git, not the logs.
 - [ ] **B15 · explore-vs-produce** — M · both — first schema extension (migration
   `0002_*.sql` — shipped migrations are immutable): split `tool_calls` into
   read/search/command/write counts → a validator explaining *why* `$`/100 lines
@@ -92,10 +84,12 @@ existing store columns; none needs a migration.
 
 ## v0.4 — "Outcome & truth"
 
-- [ ] **B18 · local survival MVP** — L · both — `assaio-agent survival`: correlate
-  AI-heavy days per project with `git log --numstat`/blame after N days in the same
-  local repo. Heavy error bars, age-matched comparisons only, explicitly directional —
-  the stepping stone toward server-side git/issue-tracker correlation.
+- [ ] **B18 · survival: per-day correlation + age-matching** — M · both — the shipped
+  `survival` command reports window-level survival of a repo's commits beside the store's
+  AI lines. Still to add: per-day AI-heavy vs quiet-day survival comparison (does code from
+  AI-heavy days survive at a different rate?), an age/settle threshold so recent commits
+  aren't counted as "survived", and rename-following in blame. Server-side git/issue-tracker
+  correlation across the team remains the larger "Outcome & quality" stage.
 - [ ] **B19 · vendor billing reconciliation** — M/L · both — opt-in pull of
   Anthropic/OpenAI usage/cost APIs; estimate-vs-actual delta with a confidence band.
   Network- and credential-gated; pulls vendor aggregates only, never uploads logs.
@@ -126,8 +120,9 @@ existing store columns; none needs a migration.
   (project-level only, never people).
 - [ ] **B28 · rhythm** — S · both — day-of-week × hour heatmap plus after-hours
   share; explicitly never an attendance view.
-- [ ] **B29 · session-taxonomy** — M · both — conversational / light-edit /
-  heavy-edit / thrash buckets and their trend; conversational is real work, says so.
+- [ ] **B29 · session-taxonomy: thrash + trend** — M · both — the shipped `session-taxonomy`
+  validator buckets conversational / light-edit / heavy-edit; still to add a thrash bucket
+  (needs per-session rework, not stored yet) and the mix's week-over-week trend.
 - [ ] **B30 · delegation** — M · solo — sub-agent economics: delegation share trend,
   tokens per delegated vs main-loop session, lines-per-token with vs without
   delegation. Task difficulty is invisible — a prompt to look, not a verdict.
@@ -135,9 +130,9 @@ existing store columns; none needs a migration.
   (ActiveMinutes); labeled an activity rate, never a productivity score.
 - [ ] **B32 · rework-bursts** — S/M · both — rework clustered over time and per-session
   p90; healthy iteration churns too.
-- [ ] **B33 · reasoning-share** — S · solo — reasoning-token share by model/project
-  with trend; flags paying for deep reasoning on shallow tasks. Only for tools that
-  report it (coverage-meter discloses which).
+- [ ] **B33 · reasoning-share: per-project + trend** — S · solo — the shipped
+  `reasoning-share` validator reports the overall reasoning share of reporting-tool output
+  plus its coverage; still to add the per-model/project breakdown and a week-over-week trend.
 - [ ] **B34 · model-freshness / lock-in** — S · both — single-model dependence and
   share of usage on unknown/legacy-priced models.
 - [ ] **B35 · entrypoint-mix** — S · both — CLI vs IDE vs hook usage and where
@@ -151,8 +146,17 @@ existing store columns; none needs a migration.
 
 - [ ] **B38 · friction-events** — M · both — tool errors / API errors / retries
   extracted from logs → an error-rate trend; needs per-tool log research.
-- [ ] **B39 · Gemini CLI + Cline activity extraction** — M/L · both — close the
-  "cost but no lines" gap (also on ROADMAP); multiplies every activity validator.
+- [ ] **B39 · Cline activity extraction** — M · both — close the "cost but no lines" gap
+  for Cline: `ui_messages.json` `say:"tool"` payloads (`newFileCreated` /
+  `editedExistingFile` / `appliedDiff`) and `api_conversation_history.json` tool_use blocks
+  carry the paths and diffs, so lines added/removed are derivable. Multiplies every activity
+  validator. Gemini CLI's default recording carries only tool-call *names*, not diffs — its
+  edit activity needs the opt-in telemetry export (B72), so it is split out.
+- [ ] **B72 · Gemini activity via OpenTelemetry** — M · both — Gemini CLI's structured edit
+  data (`ToolCallEvent.model_added_lines`/`model_removed_lines`, `FileOperationEvent`) lives
+  only in its **opt-in** OTel export, not the default session JSONL. An optional connector
+  could read a user-configured OTLP file export where enabled; strictly opt-in and clearly
+  labeled, since most installs won't have it on.
 
 ## Pool — robustness
 
@@ -173,9 +177,6 @@ existing store columns; none needs a migration.
 - [ ] **B70 · subpaths composite index** — S · both — add `(project, ts)` index for the
   dashboard drill query (`WHERE project = ? AND ts >= ?`); today it range-scans `idx_usage_ts`.
   Perf only at local scale; ship with the next schema migration.
-- [ ] **B71 · Cline editor-variant discovery** — S · both — also discover Cline task dirs
-  under VS Code Insiders / VSCodium / Cursor `globalStorage` publisher roots, not just
-  stable VS Code + the Cline CLI. Needs a verified sample per editor.
 
 ## Pool — team
 
@@ -225,8 +226,15 @@ Each follows the [connector intake flow](docs/extending.md#the-intake-path-open-
 a tool used by one organization is usually better served by an out-of-tree
 [exec plugin](docs/extending.md#write-a-plugin-any-language).
 
-- [ ] **B52 · opencode** — M — session-granularity local logs (per ROADMAP).
-- [ ] **B53 · Copilot CLI** — M — session-granularity local logs (per ROADMAP).
+- [ ] **B52 · opencode** — M — `~/.local/share/opencode/storage/message/**` JSON (plus a
+  newer relational `opencode.db`). Assistant messages carry `tokens{input,output,reasoning,
+  cache{read,write}}`, `cost`, `modelID`, and — richest of any candidate — the `edit` tool
+  persists a structured `filediff{additions,deletions,patch}`, so lines +/- are stored
+  directly, no diff parsing. The best activity target after the current four.
+- [ ] **B53 · Copilot CLI** — M — `~/.copilot/session-state/<id>/events.jsonl` (+ a
+  `session-store.db`). Dir layout is solid, but per-turn token counts and edit-diff fields
+  are not in the public schema; tokens appear only in an opt-in OTel export
+  (`~/.copilot/otel/*.jsonl`). Verify field shapes on a real session before building.
 - [ ] **B54 · Factory droid** — M — session-granularity local logs (per ROADMAP).
 - [ ] **B55 · Cursor (Admin API)** — M — local storage verified to lack token counts;
   vendor-aggregate granularity, tagged as such.
@@ -234,12 +242,18 @@ a tool used by one organization is usually better served by an out-of-tree
 - [ ] **B57 · community plugin registry page** — S — a docs page listing community
   exec plugins (parsers and metrics) once a few exist, seeded with the weekend-usage
   example.
-- [ ] **B60 · Roo Code + Kilo Code (Cline family)** — S/M — both are Cline forks with
-  the same task-directory storage under their own VS Code `globalStorage` publisher
-  ids; parameterize the existing Cline parser over publisher roots instead of writing
-  new parsers. Needs a verified sample per fork (connector issue).
-- [ ] **B61 · Qwen Code (Gemini family)** — S — a Gemini CLI fork; likely the existing
-  Gemini parser pointed at `~/.qwen`. Needs a verified sample.
+- [ ] **B60 · Roo Code + Kilo Code (Cline family)** — S/M — both are Cline forks with the
+  same task-directory storage under their own VS Code `globalStorage` publisher ids: Roo is
+  `rooveterinaryinc.roo-cline` (format confirmed identical to Cline's `api_req_started`
+  shape, plus an ignored `apiProtocol` field); Kilo is `kilocode.kilo-code` (inferred from
+  lineage, token shape not yet source-verified). Parameterize the existing Cline parser over
+  publisher roots **and a per-fork tool name** — so Roo/Kilo attribute distinctly, not as
+  `cline` — instead of writing new parsers. Still needs a verified sample per fork.
+- [ ] **B61 · Qwen Code (Gemini family)** — M — a Gemini CLI fork, but **not** the same
+  on-disk shape: chats live at `~/.qwen/projects/<hash>/chats/<id>.jsonl` (not
+  `tmp/*/chats`), and tokens are in a raw-API `usageMetadata` object, not Gemini's
+  normalized `tokens{…}`. It also persists tool-call args, so unlike Gemini it carries edit
+  activity. Needs its own parser, not the Gemini one; verify a real sample first.
 - [ ] **B62 · Continue** — M — `~/.continue` dev-data event logs reportedly carry
   token counts; verify shape via a connector issue before building.
 - [ ] **B63 · Goose** — M — local session JSONL reportedly carries usage; verify.
@@ -250,6 +264,28 @@ a tool used by one organization is usually better served by an out-of-tree
   code, no token counts — Cursor's local storage is verified to lack them). Would ship
   as lines/activity with `granularity`/provenance honestly tagged, complementing the
   Admin-API cost path (B55). Research item.
+
+## Pool — code health (0.3 candidates, from the pre-0.2 review)
+
+Deferred cleanups surfaced by the max-effort review of the 0.2 work; no behavior change, so
+they wait behind features but keep the growing metric surface maintainable.
+
+- [ ] **B73 · validator meta** — S · both — embed a `meta{name,title,describe,howToRead}`
+  value in each validator so the twelve metrics stop repeating the three trivial interface
+  methods and the duplicated `Result` header; one source of truth per metric.
+- [ ] **B74 · member aggregate** — S · team — collapse `dashboard/team.go`'s four parallel
+  per-member maps (`lines`/`cost`/`hasCost`/`unpriced`) into one `map[string]memberAgg`, so a
+  member's totals travel as a unit.
+- [ ] **B75 · humanize helpers** — S · both — unify the four K/M/B number formatters
+  (`compactCount`, `money`, `formatCompactUSD`, `formatCompactTokens`) behind one shared core
+  so token and USD glance-figures read consistently across CLI and dashboard.
+- [ ] **B76 · cli/common.go** — S · both — split the shared cross-command helpers
+  (`addDBFlag`, `resolveDBPath`, `openReportStore`, `emptyStoreHint`, `emptyStatusHint`,
+  `compareFormatConflict`, `parseSinceAt`) out of the single-command `report.go` (now past the
+  ~200-line budget) into a `cli/common.go`.
+- [ ] **B77 · readWhenEnough** — S · both — factor the "gate the favorable read behind a
+  minimum-sample floor, else neutral" block shared verbatim by session-taxonomy,
+  turn-efficiency, and model-right-sizing into one helper beside `readFor`.
 
 ## Refusals (will not build, regardless of demand)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,82 @@ Discussion.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-22
+
+### Added
+- **Three `analyze` validators.** `coverage` (Coverage & Confidence) — the provenance meter:
+  what share of a window's tokens come from tools with full activity capture vs cost-only
+  sources, and what share is priced. `cache-hygiene` (Cache Hygiene) — prompt-cache reuse
+  (cache-read share of billed input) with an honest cache-write-waste flag. And
+  `subscription-fit` (Subscription Fit) — for flat-plan users (Claude Max/Pro, ChatGPT
+  Plus/Pro): projects the window's API-equivalent estimate to a month and compares it against
+  your configured `pricing.monthly_subscription_cost`, so the estimate reads as plan value
+  (a "137x — paying off" verdict) instead of a meaningless spend figure.
+- **Four behavioral `analyze` validators** from session and per-turn data: `session-taxonomy`
+  (conversational / light-edit / heavy-edit session mix), `turn-efficiency` (one-shot rate,
+  median turns per code-producing session, output per turn), `model-right-sizing` (premium-model
+  turns that produced little output — downgrade candidates, reframed as speed/limits on a flat
+  plan), and `reasoning-share` (extended-thinking share of output, honest about which tools
+  report it). Twelve built-in validators in total.
+- **`survival` command** — the first local outcome signal: for a git repository, how much of
+  the window's commits still live in `HEAD` (via `git blame`), shown beside the AI lines the
+  store recorded for that project. Directional and honest — it never attributes specific lines
+  to AI (assaio counts lines, not code) — and the stepping stone toward server-stage git/issue
+  correlation. Plus [`docs/automation.md`](docs/automation.md): git-hook and scheduled recipes
+  to keep the store fresh, push it to a self-hosted team server, and run `survival` on a timer.
+- **Dashboard unpriced honesty.** Cost figures that exclude usage on unpriced models are
+  now marked `*` (main cost basis and per-member team costs), with a colophon note —
+  matching the CLI tables instead of showing a silent floor.
+- **Cline discovery across editors.** Cline task data is now found under VS Code Insiders,
+  VSCodium, and Cursor (not just stable VS Code), using the same `saoudrizwan.claude-dev`
+  global storage — so Cline usage in any of those editors is counted, not silently missed.
+
+### Fixed
+- **Coverage rounding.** In the `coverage` validator, a small but nonzero token share (e.g. a
+  few Codex sessions dwarfed by Claude's cache-read volume) now reads `<1%` instead of `0%`
+  (which looked absent), and a share just under whole reads `>99%` instead of a gap-hiding
+  `100%` — the honesty backbone must not round either edge away.
+- **Gemini session ids.** The real Gemini CLI recording carries the session id only on the
+  file's header line, not on every message, so message records were left with an empty
+  session id. The parser now carries the header's id forward (an older per-line shape still
+  works), and skips `$set`/`$rewindTo` control records without miscounting them.
+  **Compatibility:** this changes the dedupe key for header-only Gemini logs, so if you
+  ingested Gemini usage under v0.1.x, run `assaio-agent clear --tool gemini-cli --yes` then
+  `assaio-agent backfill` once after upgrading to avoid double-counting those records.
+- **Reasoning tokens no longer double-counted.** Codex and Gemini report reasoning as a
+  subset of output; the grand token totals added it a second time, inflating every token
+  count (cost was unaffected). Totals now count it once.
+- **Anonymized dashboard no longer leaks real subpath names.** The drill-down's
+  repository-subpath table was passed through verbatim under `--anonymize`, exposing paths
+  like `apps/mobile` beside a pseudonymized project; subpaths are now pseudonymized too.
+- **Team server rejects an empty `session_id`/`dedupe_key`.** An empty dedupe key collapsed
+  every such row into one under `ON CONFLICT DO NOTHING`, silently undercounting a member.
+- **Config validation is enforced on every command.** A typo'd honesty-relevant setting
+  (e.g. a misspelled `pricing.mode`) or a duplicate plugin name now errors instead of
+  silently reverting; `config` still validates-and-warns so it can display a broken file.
+- **Period-over-period movers are deterministic.** Tied cost deltas (common when groups are
+  all unpriced) kept a random order across runs; they now sort stably with a name tiebreak.
+- **Throughput top-project bars cover the whole window**, matching the "AI lines total"
+  headline instead of a recent-only sub-window with no label.
+- **Cline recovers a truncated `ui_messages.json`.** A read racing Cline's live rewrite
+  lost the whole task; the array is now streamed, keeping every message before the break
+  (skip-and-count, per the parser contract).
+- **Plugin I/O robustness.** A plugin's newline-free stderr flood is bounded instead of
+  growing memory unbounded; a stdout-cap breach is now reported as such and the child
+  killed promptly, instead of being misreported as a timeout. String fields on pushed and
+  plugin-emitted records are length-capped at the boundary.
+- **Codex timestamps.** A `session_meta` whose payload omits a timestamp no longer resets
+  the record timestamp to the zero time. Cline model resolution is now deterministic.
+- **Schema migrations apply atomically** with their bookkeeping row, so a crash mid-migration
+  can't leave a half-applied migration that re-runs next boot.
+- **`clear` guards.** An unknown `--tool` value (e.g. `claude` for `claude-code`) now errors
+  instead of silently deleting nothing, and `--all` combined with `--older-than`/`--tool`
+  is rejected as contradictory rather than silently narrowing the deletion.
+- **`--db`-aware empty-store hints.** `effectiveness`, `status`, and `analyze` no longer tell
+  a `--db` user to run `backfill` (which only writes the local store). `--compare` now errors
+  instead of silently ignoring `--format json|csv`. `doctor` reports a store-count error
+  instead of printing `ok`.
+
 ## [0.1.1] - 2026-07-20
 
 ### Fixed
@@ -96,6 +172,7 @@ Discussion.
 - Cost honesty throughout: every `$` disclosed as an estimate at public
   pay-as-you-go API prices; unpriced models render an honest blank, never a fake `$0`.
 
-[Unreleased]: https://github.com/assaio/assaio/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/assaio/assaio/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/assaio/assaio/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/assaio/assaio/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/assaio/assaio/releases/tag/v0.1.0

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -23,6 +23,7 @@ mattering the moment a second release exists.
 | `sync` | v0.1 | Pushes local usage to a team server; pseudonymous by default, `--member` is an explicit opt-in. |
 | `doctor` | v0.1 | Detected tools, resolved log roots, store inventory, health, accuracy caveats. |
 | `status` | v0.1 | Terminal overview: inventory, headline `$`/100 lines, hot / going-stale projects, session stats. |
+| `survival` | Unreleased | Directional local outcome check: how much of a git repo's window survives in `HEAD` (`git blame`), beside the AI lines the store recorded. See [automation](docs/automation.md). |
 | `clear` | v0.1 | Deletes stored data; requires an explicit scope and `--yes`. |
 | `config` | v0.1 | Prints the effective merged configuration and its source path. |
 | `plugins` | v0.1 | `list` / `verify` for exec **parser** plugins (protocol conformance, nothing stored). |
@@ -37,10 +38,17 @@ generically by the CLI, JSON output, and the dashboard.
 | Validator | Since | Question it answers | Built-in caveat |
 |-----------|-------|--------------------|-----------------|
 | `adoption` | v0.1 | How broad is AI usage (sessions, active days, project/tool breadth) and is it growing? | Breadth, not quality. |
+| `cache-hygiene` | Unreleased | Prompt-cache reuse: cache-read share of billed input, and whether cache writes are reused. | Cost signal, not quality; a big one-shot task legitimately shows low reuse. |
 | `context` | v0.1 | Are sessions healthy: turns, peak context, focused minutes, compaction rate? | Neutral below 3 sessions — no verdict from thin data. |
+| `coverage` | Unreleased | How much of the window is high-confidence data: token share from tools with full activity capture, and share priced. | Per-record granularity (turn vs session) not yet surfaced. |
 | `model-fit` | v0.1 | Premium vs cheaper token share (by real price tier), lines-per-token contrast, sub-agent delegation share, upper-bound routing savings. | Savings figure is an upper bound, never a switch recommendation. |
+| `model-right-sizing` | Unreleased | Premium-model turns that produced little output — downgrade candidates a cheaper/faster model might handle. | Task difficulty is invisible; a prompt to review, not a verdict. On a flat plan it's about speed/limits, not $. |
+| `reasoning-share` | Unreleased | Extended-thinking (reasoning) share of output among tools that report it, and how much of your output that covers. | Only Codex/reasoning models report it today; Claude Code doesn't. |
 | `rework` | v0.1 | Within-session churn (AI lines undone in the same transcript) and human rejection rate. | Directional friction proxy; healthy iteration churns too. |
+| `session-taxonomy` | Unreleased | The mix of session kinds: conversational (no edits), light-edit, heavy-edit — how you actually use AI. | Descriptive, not a scorecard; conversational is real work. A thrash bucket needs per-session rework (not stored yet). |
+| `subscription-fit` | Unreleased | For flat-plan users: the window's API-equivalent projected to a month vs the configured plan cost — a value multiple and an "is it paying off?" verdict. | API-equivalent is an estimate at public prices, not your bill; needs `pricing.monthly_subscription_cost`. |
 | `throughput` | v0.1 | Total AI lines, lines per active day, top projects, week-over-week trend. | Activity rate, never a productivity score. |
+| `turn-efficiency` | Unreleased | Getting more per prompt: one-shot rate, median turns per code-producing session, output tokens per turn. | Task size is invisible; directional, never a per-person score. |
 
 Exec **metric plugins** (below) render beside these, namespaced `plugin:<name>`.
 
@@ -68,7 +76,8 @@ Exec **metric plugins** (below) render beside these, namespaced `plugin:<name>`.
 
 Shared parser guarantees: skip-and-count on corrupt lines, deterministic dedupe keys
 (re-runs never double-count), `Granularity` honesty (session-level data never
-masquerades as per-turn), fuzz tests with committed corpora.
+masquerades as per-turn), fuzz tests with committed corpora. Cline task data is
+discovered across VS Code, VS Code Insiders, VSCodium, and Cursor.
 
 ## The Assay dashboard
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,214 +1,137 @@
 # Roadmap
 
-**This roadmap is conceptual, not contractual.** It sketches a direction, not a
-schedule: no committed dates, no fixed order, and no guarantee that a candidate below
-ships as described, or ships at all. `assaio` is pre-1.0 and pre-first-release, and the
-most useful input to what comes after v0.1 is real feedback from people running it
-against their own repos and teams — not a plan written in a vacuum before anyone has.
-Expect this document to change, sometimes a lot, as that feedback arrives. Read
-"we're exploring," "likely," and "candidate" literally: they mean exactly that, not a
-softer way of saying "planned."
+**This roadmap is direction, not commitment.** It sketches where `assaio` is headed and
+why — no dates, no fixed order, no guarantee that any candidate below ships as described,
+or ships at all. `assaio` is pre-1.0, and the most useful input to what comes next is real
+feedback from people running it against their own repos and teams. Read "exploring,"
+"likely," and "candidate" literally. Expect this document to change, sometimes a lot.
 
-This document is the narrative direction. Two finer-grained companions track the
-concrete state: [BACKLOG.md](BACKLOG.md) holds the ranked pool of candidate work items
-(ids, effort, honesty caveats), and [FEATURES.md](FEATURES.md) inventories what exists
-today and since which release; shipped items graduate through
-[CHANGELOG.md](CHANGELOG.md).
+This file is the **narrative** — the themes and the reasoning behind them. Three companions
+hold the specifics, and this roadmap deliberately does not repeat them:
 
-One section below is a statement of fact rather than direction: what has actually
-shipped in v0.1.
+- **[FEATURES.md](FEATURES.md)** — what exists today, and since which release.
+- **[CHANGELOG.md](CHANGELOG.md)** — the per-release delta.
+- **[BACKLOG.md](BACKLOG.md)** — the ranked pool of concrete candidate work items, each with
+  an id (`B18`), an effort estimate, and its honesty caveat. Where a theme below names a
+  `B`-id, that is where the actionable detail lives.
 
-## v0.1 — the offline agent, now (shipped)
+## The north star
 
-v0.1 started as an offline token/cost reporter. Over this cycle it grew into a fuller
-offline diagnostic agent, plus a first, honest team-server MVP. This section describes
-what is actually in the binary today, not what is planned.
+`assaio` answers one question: **is an organization's use of AI coding tools actually worth
+it** — in cost, in code that reaches and survives production, in quality, in developer
+experience? Today it measures **output and efficiency** honestly: how much AI produced, how
+much it cost, how efficiently. It does not yet measure **outcome**: whether that code was
+any good. Closing that gap — without ever fabricating a number to do it — is the throughline
+of everything below.
 
-**Coverage and accounting**
-- Four tool parsers: Claude Code, OpenAI Codex CLI, Gemini CLI, and Cline.
-- Activity extraction — AI lines added/removed, edits, tool calls, compaction,
-  within-session rework — for **Claude Code and Codex**. Gemini CLI and Cline
-  contribute cost and token counts only, not activity, until their logs get the same
-  treatment.
-- Correct cost/token accounting, including sub-agent (Task) token usage, which used to
-  be invisible — a correctness fix, not a new feature — and exact, delta-based Codex
-  accounting read from Codex's own cumulative counters, not estimated.
-- Project identity resolved to the git repository root, so a monorepo's subdirectories
-  (e.g. `apps/mobile`) roll up into one project instead of fragmenting.
+## Themes we're pursuing
 
-**Diagnostics**
-- `effectiveness` — AI output over cost, `$` per 100 AI lines, per project. A
-  directional diagnostic, not a performance score.
-- `analyze` — a validator framework (adoption, model fit, context health, throughput,
-  rework) behind one command. Each validator is a self-registering, independently
-  testable file, and the framework is the extension point for community-contributed
-  metrics.
-- **Exec metric plugins** — your own analyzer out-of-tree, in any language, declared
-  under `metrics:` in config: it reads the same prepared data every built-in validator
-  reads and renders beside them in `analyze` and the local dashboard, namespaced
-  `plugin:<name>`, with `metrics verify` as the conformance tool (ADR 0004). The team
-  server deliberately does not execute them.
-- Insights — hot / going-stale / dormant-tool / inventory views over the same data.
-- Session analytics — turns, peak context, resume-safe active minutes, compaction
-  rate, and code-producing vs. conversational session share.
-- Rework/churn — the within-session thrash proxy: AI-added lines removed again in the
-  same transcript.
-- **The Assay** — a self-contained, offline HTML dashboard: light and dark, a
-  "how to read" explainer per section, a bounded project drill-down, and an
-  i18n-scaffolded template (English only today, but structured for another locale).
+### 1. Outcome & quality — the big one
 
-**Cost honesty and budgeting**
-- Every `$` is disclosed as an **estimate at public pay-as-you-go API prices**, not your
-  actual spend — token counts are computed server-side, and a flat-rate subscription
-  (Claude Pro/Max, ChatGPT Plus/Pro) makes the effective cost-per-token entirely
-  different. `config.pricing` lets a subscription or negotiated-rate user declare their
-  real basis (an effective `$/token` or a monthly plan cost), so reports show a truer
-  figure alongside the estimate.
-- `check` — an exit-code budget gate for CI or a pre-push hook: non-zero when usage
-  exceeds a **token** budget (the plan-independent default) or an optional, clearly
-  labeled API-equivalent `$` budget.
-- Model-routing savings — the `model-fit` litmus turns its premium/cheaper split into a
-  directional, **upper-bound** estimate ("premium-tier tokens repriced on the cheapest
-  cheaper model ≈ $X/mo"), explicitly a prompt to review, never an auto-applied switch.
-- Period-over-period `--compare` on `report` and `effectiveness` — top movers by cost and
-  AI lines vs. the previous equal window, so "what changed" leads.
-- `demo` — the full reports on bundled sample data, no logs needed, for an instant first
-  look before importing your own history.
+The measurements that matter most to the north star are the ones local logs cannot honestly
+answer alone. Whether AI-written lines **survived** in `main` after review and rewrites,
+whether they **caused bugs** (only ever against age-matched human code, never a raw
+AI-vs-human split), whether they held up as **maintainable** work alongside DORA- and
+DX-style signals — all of it needs correlation against git history and an issue tracker.
+That is the real reason a server exists in this project, not a growth-stage default. The
+path we're exploring: a local `survival` MVP first (correlate AI-heavy days against
+`git log`/blame in the same repo, heavy error bars, explicitly directional — `B18`), then
+server-side correlation proper (GitHub first; GitLab, Bitbucket, Jira as breadth once the
+core works). Everything here ships with its error bars or it does not ship.
 
-**Team and sharing**
-- A team-server MVP: `serve` runs a self-hosted collection endpoint behind a shared
-  bearer token, `sync` pushes an agent's local usage to it, pseudonymized by default
-  (`--member` is an explicit opt-in to a real name).
-- A per-member Team section on the Assay dashboard, and a team-aware CLI (`--db` to
-  point any read command at a central store, `--by member` to group by it) —
-  aggregated and pseudonymized by default, the same governed-opt-in posture as the
-  rest of `assaio`.
+### 2. Coverage & truth
 
-**Robustness**
-- Schema self-heal: an existing local database migrates itself forward, no manual
-  step.
-- User-configurable log-source paths, for non-default install locations.
-- Anonymization on by default for anything meant to be shared (the dashboard); the
-  interactive CLI still shows real names, since those never leave your machine.
+Two directions, one goal: every tool a team actually uses should be counted, and every `$`
+should be reconcilable against reality.
 
-This is still, honestly, an **output and efficiency** measurement, not an **outcome**
-one: it says how much AI produced and how efficiently, never whether that code was any
-good. Closing that gap is the whole subject of what's next.
+- **More tools.** The activity gap (some tools contribute cost but no line/edit signals) is
+  the priority, because closing it multiplies every activity metric. Cline-family logs carry
+  the diffs needed for line extraction (`B39`); `opencode` stores structured
+  additions/deletions per edit and is the richest next target (`B52`); the Cline forks Roo
+  and Kilo Code (`B60`) and the Gemini fork Qwen (`B61`) reuse most of an existing parser;
+  Aider (`B14`) and Copilot CLI (`B53`) round out the shortlist. Out-of-tree
+  [exec-plugin connectors](docs/extending.md) already let anyone add a source in any
+  language without waiting for a core release — a tool used by one organization is usually
+  better served that way.
+- **Cost truthfulness.** Every `$` is an estimate at public pay-as-you-go API prices, which
+  a flat-rate subscription makes structurally different from real spend. Two candidates
+  close the gap: opt-in **vendor billing reconciliation** (pull Anthropic/OpenAI usage
+  APIs, show the estimate-vs-actual delta with a confidence band — `B19`), and **tiered /
+  context-length pricing** (long-context and distinct cache read/write rates a single
+  per-model number can't capture — `B16`).
 
-## What's next
+### 3. Richer local views
 
-Everything below is a direction we're exploring, grouped by theme rather than pinned
-to a version number — what actually comes next follows from what pilot users ask for,
-not from this list's order.
+A large shortlist of metrics can be honestly supported from data already stored — no git, no
+issue tracker, no schema change. These are the fast, frequent wins: turn-efficiency
+("am I getting more per prompt?"), subscription-fit (is Max/Pro paying off vs API?),
+cost concentration across projects, a workload rhythm heatmap (never an attendance view),
+session-outcome taxonomy, throughput per focused hour, rework/thrash bursts over time, and a
+self-relative "skill curve" progress panel (you vs you four weeks ago, never cross-person).
+Each is one self-registering file and each carries the caveat that keeps it honest — see the
+`B01`–`B37` cluster in the backlog.
 
-### Deeper impact & quality — the big one
+### 4. Team & server hardening
 
-Needs git and issue-tracker correlation, so it needs a server, not the local agent.
-v0.1 can tell you AI *produced* 300 lines; it cannot tell you whether those lines:
+The team server is a deliberate MVP and says so in its own code. Making it fit for more than
+a trusted network: TLS or clear reverse-proxy guidance, real per-member auth and access
+control, chunked and resumable sync for large backfills, and configurable retention (`B22`).
+On top of that, team-shaped views that never become a leaderboard: adoption evenness
+(Lorenz/Gini across pseudonymized members with a minimum-cohort guard), tool coverage and
+shadow-tool detection, an onboarding curve in aggregated bands, and server-side computation
+of metric-plugin results (safely, never per unauthenticated request). Pushing to the server
+is already config-driven — `sync` sends to any host with a token — so repointing at a
+hardened server, or an eventual **managed cloud**, is a settings change, not a rebuild; that
+cloud is where this theme's hardening (per-member auth, retention, TLS) ultimately lands.
 
-- **Survived** in `main` after review, rewrites, and reverts — not just that they were
-  written.
-- **Caused bugs**, measured only against age-matched human code, never a raw
-  AI-vs-human split.
-- Held up as **quality and maintainable** code, alongside DORA- and DX-style
-  engineering metrics.
+### 5. Ecosystem & extensibility
 
-None of this is honestly answerable from local logs alone — that is the actual reason
-a server exists in this project, not a growth-stage default. It would correlate synced
-usage against git history first, and an issue tracker next (GitHub to start; GitLab,
-Bitbucket, and Jira are candidate breadth once the core correlation works).
+`assaio` is built to be extended, and the extension surfaces should become dependable
+enough to build a community on. Directions: a third exec-plugin protocol for **rule** units
+(read a window's verdicts, emit alerts with severity — `B13`, ADR 0005 to come); an
+in-process Go **plugin API** (`plugin/metric|rule|connector`, no subprocess, no rebuild —
+`B24`); a published, versioned freeze of the plugin protocols and the SQLite schema under
+semver (`B23`); JSON Schemas and a scaffolder for plugin authors; and a community registry
+page once a few plugins exist. The core rule holds: `internal/` never depends on `plugin/`
+or `ee/`.
 
-### Server hardening
+### 6. Developer experience
 
-The `serve`/`sync` MVP that shipped this cycle is an honest MVP, and says so in its own
-code: one shared bearer token, no TLS, no chunked or resumable sync, no retention
-policy — built to run behind a reverse proxy on a trusted network, not exposed to the
-open internet. Likely next: TLS or clear reverse-proxy guidance, real per-member auth
-and access control, chunked and resumable sync for large backfills, and configurable
-retention.
+The daily-habit and integration layer: an ambient status-line one-liner (today's cost, burn
+rate, budget remaining), an interactive TUI, an MCP server so you can ask your own usage
+questions from an agent, a weekly markdown digest fit for cron, a packaged GitHub Action
+(the `check` gate plus a PR comment), shell completions and man pages, data exports
+(OpenMetrics for Grafana, ndjson/parquet for data teams), and growing the dashboard's
+i18n scaffold into real locales as people ask.
 
-### Cost truthfulness — reconciliation and real rates
+### 7. Scale
 
-v0.1 is honest that every `$` is an *estimate at public pay-as-you-go API prices*, not
-your actual spend: token counts are computed server-side and are structurally
-unobservable to an offline client, and a subscription (Claude Pro/Max, ChatGPT Plus/Pro)
-bills a flat rate that makes the effective cost-per-token entirely different. `config.pricing`
-already lets a subscription or negotiated-rate user declare their real basis, and `check`
-gates on tokens — the plan-independent primitive — by default. Two directions close the
-rest of the gap, both candidates:
+Reserved for when the current shape stops being enough, not before: a Postgres backend once
+a single SQLite file no longer suffices for a central store (`B25`), and dashboard depth
+(multi-window tabs, sparklines, top-N drilldowns) as reports carry more history.
 
-- **Vendor billing reconciliation.** Where a vendor exposes actuals (Anthropic's and
-  OpenAI's usage/cost APIs), an opt-in reconciliation would pull those aggregates and
-  show the estimate-vs-actual delta with a confidence band — the honest close on "is my
-  estimate right?", and the real answer to the subscription gap. Strictly opt-in,
-  network- and credential-gated; it pulls vendor aggregates only and never uploads logs.
-- **Tiered and context-length pricing.** The embedded price table is flat per model; real
-  pricing has tiers — long-context premiums (e.g. a `[1m]` 1M-context rate) and distinct
-  cache read/write rates a single per-model number can't capture. Modeling those would
-  sharpen the estimate for the heaviest, long-context sessions, where it matters most.
+## Principles that don't change
 
-### Richer views (candidates from research)
+No theme above is allowed to weaken these:
 
-We ran a research pass across the DORA / SPACE / DX Core 4 / METR / Faros literature
-asking one question: what else can the same local logs honestly support, with no git
-and no issue tracker? Its ranked shortlist is longer than this; these are the
-candidates we're most likely to explore first — each still an idea under evaluation,
-not a commitment, and each carrying the caveat that keeps it honest:
+- **Measure value, not people.** Aggregated and pseudonymized views are the default at every
+  stage; a per-person view is only ever a deliberate, governed opt-in in team mode — never
+  silent, never a leaderboard, never built for individual performance evaluation.
+- **Honest statistics or nothing.** Every domain fact carries its provenance and confidence;
+  attribution and effectiveness claims ship with their error bars; a directional signal is
+  labeled directional.
+- **The refusals hold regardless of demand:** no "estimated time saved" headline (the logs
+  contain no counterfactual), no lines-of-code or token leaderboard, nothing ranked per
+  named individual, and no cohort/percentile comparison without a minimum cohort size and
+  explicit consent.
+- **The core stays Apache-2.0** throughout; commercial modules, if any, stay isolated under
+  `ee/`.
 
-- **Provenance/confidence coverage meter** — one figure for how much of a given report
-  is high-confidence data vs. thin or partial coverage; the honesty backbone the rest
-  of this list leans on.
-- **Cache-reuse efficiency trend** — cache-read share over time. High reuse is
-  cheaper, not "better work"; a big one-shot task legitimately shows low reuse.
-- **Session-outcome taxonomy** — conversational / light-edit / heavy-edit / thrash
-  buckets. Conversational is not waste — design and debugging sessions are real work.
-- **Time-of-day / day-of-week rhythm** — a workload heatmap with an after-hours/weekend
-  guardrail. Explicitly never an attendance or "who works late" view.
-- **Cost concentration (Pareto/Lorenz)** — which projects drive most of the spend.
-  Project-level only, never computed across named people.
-- **Model right-sizing & in-session switching** — flags a possibly-overpowered model
-  on a small turn. Task difficulty is invisible in logs, so this is a prompt to look,
-  not a verdict.
-- **Throughput per active hour** — the shipped `throughput` validator tracks raw
-  AI-line volume and its week-over-week trend; this candidate would normalize by
-  focused time instead. Labeled an activity rate, not a productivity score.
-- **Rework/thrash bursts over time** — the shipped rework rate, broken out per-session
-  and over time to see where churn clusters. Rework is not failure; healthy iteration
-  churns too.
+## How we prioritize
 
-The refusals hold regardless of what ships from this list: no "estimated time saved"
-headline (logs contain no counterfactual), no lines-of-code or token leaderboard, and
-nothing ranked per named individual, ever.
-
-### More tool coverage
-
-- Activity extraction (AI lines, edits, rework) for Gemini CLI and Cline, closing the
-  gap with Claude Code and Codex.
-- More exec-plugin connectors — the protocol (ADR 0003) already lets anyone add one
-  out-of-tree, in any language, without a core release. Candidates on our radar:
-  opencode and Copilot CLI and Factory droid at session granularity, Cursor via its
-  Admin API only (its local storage has been verified to lack token counts), and Kiro
-  if its logs turn out to carry real token data.
-
-### DX niceties
-
-- The dashboard's i18n scaffolding (one `localeStrings` struct, English only today)
-  was built with a language switcher in mind. Whether it grows one depends on whether
-  anyone asks.
-
----
-
-Further out and rougher than the above: usage-anomaly alerts, a weekly digest, an MCP
-server for querying your own usage data, an ambient status-line one-liner (today's cost,
-burn rate, budget remaining), a CI pull-request comment and job-summary, honest
-cohort/percentile context (never a rank, with a minimum cohort size), a stabilized plugin
-API for connectors, metrics, and rules, and a Postgres backend once a single SQLite file
-stops being enough. A few minor, non-blocking polish items surfaced in the pre-1.0 review
-are deferred here rather than gating the release. None of this is designed yet; it's
-further-out direction, not a queue.
-
-The core stays Apache-2.0 throughout. One design principle holds regardless of what
-above changes: **measure value, not people, by default.** Aggregated and pseudonymized
-views are what `assaio` produces out of the box at every stage; a per-person view is
-only ever a deliberate, governed opt-in in team mode — never silent, never a
-leaderboard, never built for individual performance evaluation.
+Order follows real-world feedback, pull requests, and bug reports — not this document's
+sequence, and things not listed anywhere can land first when a PR or a bug report makes the
+case. To weigh in: open a feature-request issue or a Discussion, or add weight to a tracked
+item by referencing its `B`-id. Connectors additionally follow the
+[connector intake flow](docs/extending.md#the-intake-path-open-a-connector-issue-first) —
+open an issue with a redacted sample before building, so the format is verified first.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,115 @@
+# Automating assaio — hooks, scheduled sync, and survival
+
+This is the operating recipe for keeping an organization's AI-usage picture fresh without a
+daemon: refresh the local store, push it to a self-hosted team server, and run the
+directional `survival` outcome check on a schedule. Everything here is opt-in, and the only
+network step is `sync` (pseudonymized by default). A managed cloud is roadmap; today the
+"company server" is one you run yourself with `serve` (see the [team server](../README.md)).
+
+## The pieces
+
+- **`backfill`** — re-imports local session logs into the store. Idempotent (deterministic
+  dedupe keys), so running it repeatedly never double-counts. Safe to run often.
+- **`sync`** — pushes local usage to a team server over one bearer-token HTTPS call,
+  **pseudonymized by default** (`--member` is an explicit opt-in to a real name). The only
+  network path; nothing else leaves the machine.
+- **`survival`** — the directional, local outcome check: how much of a repo's window
+  survives in `HEAD`, beside the AI lines the store recorded. It shells out to `git blame`,
+  so it is heavier than the others — run it periodically (e.g. weekly), not per commit.
+
+## Option A — scheduled refresh + push (recommended)
+
+A small timer keeps the store fresh and pushes it to the company server. This is more
+robust than a git hook: it runs whether or not you committed, and never blocks anything.
+
+A wrapper script the timer runs — `~/.local/bin/assaio-refresh`:
+
+```sh
+#!/bin/sh
+set -eu
+assaio-agent backfill >/dev/null
+assaio-agent sync --server "https://assaio.example.com" --token "$ASSAIO_SYNC_TOKEN"
+```
+
+Keep the token out of the script — read it from the environment (`ASSAIO_SYNC_TOKEN`) or a
+secret manager.
+
+**launchd (macOS)** — `~/Library/LaunchAgents/com.assaio.refresh.plist`, every 30 minutes:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.assaio.refresh</string>
+  <key>ProgramArguments</key><array><string>/Users/you/.local/bin/assaio-refresh</string></array>
+  <key>StartInterval</key><integer>1800</integer>
+  <key>EnvironmentVariables</key><dict><key>ASSAIO_SYNC_TOKEN</key><string>…</string></dict>
+</dict></plist>
+```
+
+`launchctl load ~/Library/LaunchAgents/com.assaio.refresh.plist`.
+
+**cron (Linux)** — every 30 minutes:
+
+```cron
+*/30 * * * * ASSAIO_SYNC_TOKEN=… /home/you/.local/bin/assaio-refresh >/dev/null 2>&1
+```
+
+## Option B — a git post-commit hook
+
+If you'd rather refresh right after each commit, do it **in the background** so the commit
+never waits on a full backfill. `.git/hooks/post-commit` (make it executable):
+
+```sh
+#!/bin/sh
+# Refresh assaio in the background; never block the commit.
+( assaio-agent backfill >/dev/null 2>&1 \
+  && assaio-agent sync --server "https://assaio.example.com" --token "$ASSAIO_SYNC_TOKEN" ) &
+```
+
+To install it for every repo you clone, point git at a hooks template once:
+`git config --global init.templateDir ~/.git-template` and drop the hook under
+`~/.git-template/hooks/`.
+
+## Survival on a schedule
+
+`survival` is the outcome signal — run it per repo, weekly, and log or publish the result.
+Because it blames the window's touched files, give it its own (less frequent) timer:
+
+```sh
+#!/bin/sh
+# ~/.local/bin/assaio-survival-report — one repo, appended to a log.
+cd "$1" || exit 1
+assaio-agent survival --since 90d >> "$HOME/assaio-survival.log"
+```
+
+A weekly cron entry per repo:
+
+```cron
+0 8 * * 1 /home/you/.local/bin/assaio-survival-report /home/you/src/acme-web
+```
+
+Read it as a trend over weeks: a survival rate that stays high as a repo ages is the honest,
+local answer to "is the AI-written code sticking?" — directional, never a per-line
+attribution (assaio counts lines, it does not store code).
+
+## The company server
+
+Run one `serve` instance on trusted infrastructure and point every agent's `sync` at it:
+
+```sh
+assaio-agent serve --addr :8787 --token "$ASSAIO_SERVER_TOKEN"   # behind a TLS reverse proxy
+```
+
+The server collects pushed usage and serves the aggregated, always-anonymized team
+dashboard at `/`. It is a deliberate MVP (one shared token, no TLS of its own — run it
+behind a reverse proxy on a trusted network); see the server package doc and `ROADMAP.md`
+for the hardening path (per-member auth, retention, resumable sync).
+
+## What is and isn't automated to the server today
+
+- **Usage** (tokens, cost, activity) syncs to the server and aggregates into the team
+  dashboard. This is the live picture.
+- **Survival** runs locally and prints its result; it is **not** pushed to the server yet.
+  Server-side survival — correlating synced usage against git and issue trackers across the
+  whole team — is the roadmap's "Outcome & quality" stage, and the future managed cloud.
+```

--- a/internal/analyze/analyze.go
+++ b/internal/analyze/analyze.go
@@ -45,6 +45,15 @@ type Input struct {
 	ByProject []ProjectStat
 	// Totals is Usage's grand totals across every model and project. See Totals.
 	Totals Totals
+	// PlanMonthlyCost is the user's flat monthly subscription price (config.pricing), for
+	// comparing against the API-equivalent estimate. Zero (the default) means unset, and
+	// subscription-fit then prompts to configure it rather than comparing against nothing.
+	PlanMonthlyCost float64
+	// TurnSizing is per-model raw turn counts (output-producing turns, and how many were
+	// small) for model-right-sizing, which needs the per-turn grain the daily Usage
+	// aggregate hides. Populated by the CLI from store.TurnSizing; empty in the drill and
+	// in tests that don't set it, where model-right-sizing reads "no premium turns".
+	TurnSizing []store.ModelTurns
 }
 
 // Read is a validator's headline verdict. Key drives the dashboard's color: "good",

--- a/internal/analyze/cache.go
+++ b/internal/analyze/cache.go
@@ -1,0 +1,85 @@
+package analyze
+
+import "strconv"
+
+const (
+	cacheName      = "cache-hygiene"
+	cacheTitle     = "Cache Hygiene"
+	cacheDescribe  = "Prompt-cache reuse: how much billed input was served from cache vs re-sent, and whether cache writes are being reused."
+	cacheHowToRead = "High cache reuse means repeated context is served cheaply from cache instead of re-billed as fresh input. It is a cost signal, not a quality one -- a big one-shot task legitimately shows low reuse, and vendor cache lifetimes are invisible here."
+	// cacheGoodReuse is the cache-read share above which reuse reads as healthy.
+	cacheGoodReuse = 0.5
+)
+
+func init() { Register(cacheValidator{}) }
+
+// cacheValidator reads prompt-cache efficiency: the share of input tokens served from
+// cache (cheaper) versus re-sent as fresh input, and whether cache writes are paying off.
+type cacheValidator struct{}
+
+func (cacheValidator) Name() string     { return cacheName }
+func (cacheValidator) Title() string    { return cacheTitle }
+func (cacheValidator) Describe() string { return cacheDescribe }
+
+//nolint:gocritic // Input is a small value bundle required by the Validator interface; analyzed once per CLI run, not a hot path.
+func (cacheValidator) Analyze(in Input) Result {
+	r := Result{Name: cacheName, Title: cacheTitle, Describe: cacheDescribe, HowToRead: cacheHowToRead}
+	t := in.Totals
+	if t.Input == 0 && t.CacheRead == 0 && t.CacheWrite == 0 {
+		r.Read = noDataRead
+		r.Takeaway = "No usage in this window."
+		return r
+	}
+
+	reuse := t.CacheEfficiency // CacheRead / (CacheRead + Input)
+	healthy := reuse >= cacheGoodReuse
+
+	r.Read = readFor(healthy, "Efficient")
+	r.Purity = clamp01(reuse)
+	r.Figures = []Figure{
+		{Label: "cache-read share", Value: honestPercent(reuse), Note: "of billed input"},
+		{Label: "cache reads", Value: compactCount(t.CacheRead)},
+		{Label: "cache writes", Value: compactCount(t.CacheWrite), Note: cacheWriteNote(t.CacheRead, t.CacheWrite)},
+	}
+	r.Takeaway = cacheTakeaway(healthy, t.CacheRead, t.CacheWrite)
+	r.Caveats = []string{
+		"High reuse is cheaper, not better work -- a large one-shot task legitimately shows low reuse.",
+		"Vendor cache lifetimes (TTLs) are invisible, so this is a day-grain approximation.",
+	}
+	return r
+}
+
+func cacheTakeaway(healthy bool, read, write int64) string {
+	switch {
+	case healthy:
+		return "Most repeated context is served from cache, keeping input cost down."
+	case write > 0 && read < write:
+		return "Cache is written more than it is reused -- short or churning sessions may be paying to cache context that is never read back."
+	default:
+		return "Little input is served from cache this window -- expected for one-shot or exploratory work."
+	}
+}
+
+// cacheWriteNote flags cache writes that outweigh reads: paying to cache context that is
+// not (yet) being read back.
+func cacheWriteNote(read, write int64) string {
+	if write > 0 && read < write {
+		return "written more than reused"
+	}
+	return ""
+}
+
+// compactCount renders a token count compactly, e.g. 33_400_000_000 -> "33.4B",
+// 1_500_000 -> "1.5M", 2_300 -> "2.3K". Real cache-read totals reach billions.
+func compactCount(n int64) string {
+	switch {
+	case n >= 1_000_000_000:
+		return strconv.FormatFloat(float64(n)/1_000_000_000, 'f', 1, 64) + "B"
+	case n >= 1_000_000:
+		return strconv.FormatFloat(float64(n)/1_000_000, 'f', 1, 64) + "M"
+	case n >= 1_000:
+		return strconv.FormatFloat(float64(n)/1_000, 'f', 1, 64) + "K"
+	default:
+		return strconv.FormatInt(n, 10)
+	}
+}

--- a/internal/analyze/cache_test.go
+++ b/internal/analyze/cache_test.go
@@ -1,0 +1,42 @@
+package analyze
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+// TestCacheHygieneReportsReuseShare covers the healthy path: when most billed input is
+// served from cache, the read share is reported and the takeaway says so.
+func TestCacheHygieneReportsReuseShare(t *testing.T) {
+	usage := []store.UsageRow{
+		{Day: "2026-07-10", Tool: "claude-code", Model: "claude-sonnet-4-5", Project: "web", In: 200, Out: 100, CacheRead: 800, CacheWrite: 100},
+	}
+	in := BuildInput(usage, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	got := mustGet(t, cacheName).Analyze(in)
+
+	// reuse = CacheRead/(CacheRead+Input) = 800/1000 = 80%.
+	if !strings.Contains(figureValues(got.Figures), "80%") {
+		t.Fatalf("Figures = %q, want an 80%% cache-read share", figureValues(got.Figures))
+	}
+	if !strings.Contains(got.Takeaway, "served from cache") {
+		t.Fatalf("Takeaway = %q, want the healthy-reuse message", got.Takeaway)
+	}
+}
+
+// TestCacheHygieneFlagsWriteWaste covers the honest waste signal: cache written far more
+// than it is read back is called out rather than passed off as efficient.
+func TestCacheHygieneFlagsWriteWaste(t *testing.T) {
+	usage := []store.UsageRow{
+		{Day: "2026-07-10", Tool: "claude-code", Model: "claude-sonnet-4-5", Project: "web", In: 900, Out: 100, CacheRead: 100, CacheWrite: 900},
+	}
+	in := BuildInput(usage, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	got := mustGet(t, cacheName).Analyze(in)
+
+	// reuse = 100/1000 = 10% -> not healthy, and writes far outweigh reads.
+	if !strings.Contains(got.Takeaway, "written more than it is reused") {
+		t.Fatalf("Takeaway = %q, want the cache-write-waste message", got.Takeaway)
+	}
+}

--- a/internal/analyze/coverage.go
+++ b/internal/analyze/coverage.go
@@ -1,0 +1,150 @@
+package analyze
+
+import (
+	"sort"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+const (
+	coverageName      = "coverage"
+	coverageTitle     = "Coverage & Confidence"
+	coverageDescribe  = "How much of this window is high-confidence data: the share of tokens from tools with full activity capture, and the share priced."
+	coverageHowToRead = "Coverage is the honesty backbone -- it says how much of every other figure rests on complete data. Low activity coverage means line and edit signals cover only part of your usage; low priced coverage means some cost is excluded, never a real zero."
+	// coverageStrongFloor is the share both coverage axes must clear for a confident read.
+	coverageStrongFloor = 0.8
+)
+
+func init() { Register(coverageValidator{}) }
+
+// coverageValidator reports how much of the window rests on high-confidence data: the
+// share of tokens from tools with full activity extraction (Claude Code, Codex) versus
+// cost-only sources, and the share of tokens on priced models. It is the provenance meter
+// the other validators' honesty leans on.
+type coverageValidator struct{}
+
+func (coverageValidator) Name() string     { return coverageName }
+func (coverageValidator) Title() string    { return coverageTitle }
+func (coverageValidator) Describe() string { return coverageDescribe }
+
+//nolint:gocritic // Input is a small value bundle required by the Validator interface; analyzed once per CLI run, not a hot path.
+func (coverageValidator) Analyze(in Input) Result {
+	r := Result{Name: coverageName, Title: coverageTitle, Describe: coverageDescribe, HowToRead: coverageHowToRead}
+	if in.Totals.Tokens == 0 {
+		r.Read = noDataRead
+		r.Takeaway = "No usage in this window."
+		return r
+	}
+
+	activityTokens, byTool := tokensByTool(in.Usage)
+	activityShare := fracOf(activityTokens, in.Totals.Tokens)
+	pricedShare := fracOf(pricedTokenSum(in.ByModel), in.Totals.Tokens)
+	solid := activityShare >= coverageStrongFloor && pricedShare >= coverageStrongFloor
+
+	r.Read = readFor(solid, "Solid")
+	r.Purity = clamp01(min(activityShare, pricedShare))
+	r.Figures = []Figure{
+		{Label: "activity coverage", Value: honestPercent(activityShare), Note: "lines/edits captured"},
+		{Label: "priced coverage", Value: honestPercent(pricedShare), Note: "cost known"},
+		{Label: "cost-only tokens", Value: honestPercent(1 - activityShare), Note: "no line signals"},
+	}
+	r.Bars = toolCoverageBars(byTool, in.Totals.Tokens)
+	r.Takeaway = coverageTakeaway(activityShare, pricedShare)
+	r.Caveats = []string{
+		"Cost-only tools (Gemini CLI, Cline, plugins) contribute tokens and cost but no line or edit signals -- see ROADMAP.",
+		"Per-record granularity (turn vs session) is not yet surfaced, so a mix isn't flagged here.",
+	}
+	return r
+}
+
+func coverageTakeaway(activityShare, pricedShare float64) string {
+	switch {
+	case activityShare >= coverageStrongFloor && pricedShare >= coverageStrongFloor:
+		return "Most usage carries full activity and price data -- the other figures rest on solid coverage."
+	case activityShare < coverageStrongFloor:
+		return "A large share of tokens comes from cost-only tools, so line and edit figures cover only part of your usage."
+	default:
+		return "Some tokens run on unpriced models, so cost is a floor here, not the full total."
+	}
+}
+
+// activityCapableTool reports whether tool's parser extracts line and edit activity, not
+// just tokens and cost. Update this when a cost-only parser (Gemini CLI, Cline) gains
+// activity extraction (BACKLOG B39).
+func activityCapableTool(tool string) bool {
+	return tool == "claude-code" || tool == "codex"
+}
+
+// rowTokens is a row's billable token total, matching Totals.Tokens -- reasoning tokens
+// are a subset of output (usage.Record) and are never re-added.
+func rowTokens(r *store.UsageRow) int64 {
+	return r.In + r.Out + r.CacheRead + r.CacheWrite
+}
+
+// tokensByTool sums tokens per tool and, separately, the subtotal for activity-capable
+// tools.
+func tokensByTool(rows []store.UsageRow) (activity int64, byTool map[string]int64) {
+	byTool = make(map[string]int64)
+	for i := range rows {
+		t := rowTokens(&rows[i])
+		byTool[rows[i].Tool] += t
+		if activityCapableTool(rows[i].Tool) {
+			activity += t
+		}
+	}
+	return activity, byTool
+}
+
+// pricedTokenSum totals the tokens on priced models across ByModel.
+func pricedTokenSum(models []ModelStat) int64 {
+	var sum int64
+	for i := range models {
+		if models[i].Priced {
+			sum += models[i].Tokens
+		}
+	}
+	return sum
+}
+
+// toolCoverageBars renders each tool's token share, marking cost-only tools. Bars label
+// tools, never projects, so they are never pseudonymized (BarsAreProjects stays false).
+func toolCoverageBars(byTool map[string]int64, total int64) []Bar {
+	tools := make([]string, 0, len(byTool))
+	for t := range byTool {
+		tools = append(tools, t)
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		if byTool[tools[i]] != byTool[tools[j]] {
+			return byTool[tools[i]] > byTool[tools[j]]
+		}
+		return tools[i] < tools[j]
+	})
+	var maxTok int64
+	if len(tools) > 0 {
+		maxTok = byTool[tools[0]]
+	}
+	bars := make([]Bar, len(tools))
+	for i, t := range tools {
+		label := t
+		if !activityCapableTool(t) {
+			label += " (cost only)"
+		}
+		bars[i] = Bar{Label: label, Value: honestPercent(fracOf(byTool[t], total)), Frac: fracOf(byTool[t], maxTok)}
+	}
+	return bars
+}
+
+// honestPercent renders a share without the two dishonest rounding edges: a small but
+// nonzero share reads "<1%" (not "0%", which looks absent -- e.g. a few real Codex sessions
+// dwarfed by Claude's cache-read volume), and a share just under whole reads ">99%" (not
+// "100%", which would hide a real gap). The share formatter for honesty-first figures.
+func honestPercent(share float64) string {
+	switch {
+	case share > 0 && share < 0.005:
+		return "<1%"
+	case share < 1 && share >= 0.995:
+		return ">99%"
+	default:
+		return formatPercent(share, 0)
+	}
+}

--- a/internal/analyze/coverage_test.go
+++ b/internal/analyze/coverage_test.go
@@ -1,0 +1,47 @@
+package analyze
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+// TestCoverageReportsActivityAndPricedShares checks the provenance meter: tokens from a
+// cost-only tool lower activity coverage, and tokens on an unpriced model lower priced
+// coverage, each reported as its own share -- never silently folded into the others.
+func TestCoverageReportsActivityAndPricedShares(t *testing.T) {
+	usage := []store.UsageRow{
+		// Activity-capable + priced.
+		{Day: "2026-07-10", Tool: "claude-code", Model: "claude-sonnet-4-5", Project: "web", In: 600, Out: 200},
+		// Cost-only tool, priced model.
+		{Day: "2026-07-10", Tool: "gemini-cli", Model: "claude-sonnet-4-5", In: 150, Out: 50},
+		// Activity-capable tool, unpriced model.
+		{Day: "2026-07-10", Tool: "codex", Model: "unknown-model", Project: "api", In: 800, Out: 200},
+	}
+	in := BuildInput(usage, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	got := mustGet(t, coverageName).Analyze(in)
+
+	joined := figureValues(got.Figures)
+	// total 2000; activity-capable (claude-code+codex) = 1800 -> 90%.
+	if !strings.Contains(joined, "90%") {
+		t.Fatalf("Figures = %q, want 90%% activity coverage (1800/2000)", joined)
+	}
+	// priced (models in testPrices) = the two claude-sonnet rows, 1000 -> 50%.
+	if !strings.Contains(joined, "50%") {
+		t.Fatalf("Figures = %q, want 50%% priced coverage (1000/2000)", joined)
+	}
+	if got.BarsAreProjects {
+		t.Fatal("coverage bars label tools, so they must never be pseudonymized as projects")
+	}
+	var sawCostOnly bool
+	for _, b := range got.Bars {
+		if strings.Contains(b.Label, "gemini-cli") && strings.Contains(b.Label, "cost only") {
+			sawCostOnly = true
+		}
+	}
+	if !sawCostOnly {
+		t.Fatalf("Bars = %+v, want gemini-cli marked '(cost only)'", got.Bars)
+	}
+}

--- a/internal/analyze/model_right_sizing.go
+++ b/internal/analyze/model_right_sizing.go
@@ -1,0 +1,77 @@
+package analyze
+
+import "strconv"
+
+const (
+	rightSizeName      = "model-right-sizing"
+	rightSizeTitle     = "Model Right-Sizing"
+	rightSizeDescribe  = "Turns on a premium model that produced very little output -- small tasks a cheaper, faster model might handle just as well."
+	rightSizeHowToRead = "A premium-model turn that emits only a handful of output tokens is often boilerplate or a quick answer a cheaper model handles as well. On a flat plan this is about speed and rate limits, not dollars. Task difficulty is invisible, so this is a prompt to look at a few, never a verdict."
+	// RightSizeSmallOutput is the output-token ceiling below which a premium turn is a
+	// downgrade candidate; exported so the CLI passes it to store.TurnSizing.
+	RightSizeSmallOutput = 300
+	// rightSizeWatchShare is the small-premium-turn share above which the read flags over-powering.
+	rightSizeWatchShare = 0.4
+	// rightSizeMinTurns is the premium-turn floor below which the share is too thin to report.
+	rightSizeMinTurns = 20
+)
+
+func init() { Register(rightSizeValidator{}) }
+
+// rightSizeValidator flags premium-model turns that produced little output -- small tasks a
+// cheaper or faster model might have handled -- as candidates to review, not a verdict.
+type rightSizeValidator struct{}
+
+func (rightSizeValidator) Name() string     { return rightSizeName }
+func (rightSizeValidator) Title() string    { return rightSizeTitle }
+func (rightSizeValidator) Describe() string { return rightSizeDescribe }
+
+//nolint:gocritic // Input is required by the Validator interface; analyzed once per run, not a hot path.
+func (rightSizeValidator) Analyze(in Input) Result {
+	r := Result{Name: rightSizeName, Title: rightSizeTitle, Describe: rightSizeDescribe, HowToRead: rightSizeHowToRead}
+	var premiumTurns, smallPremium int64
+	for i := range in.TurnSizing {
+		m := &in.TurnSizing[i]
+		if modelTier(m.Model, in.Prices) != tierPremium {
+			continue
+		}
+		premiumTurns += m.Turns
+		smallPremium += m.SmallTurns
+	}
+	if premiumTurns == 0 {
+		r.Read = noDataRead
+		r.Takeaway = "No premium-model turns in this window."
+		return r
+	}
+	enough := premiumTurns >= rightSizeMinTurns
+	smallShare := fracOf(smallPremium, premiumTurns)
+
+	if enough {
+		r.Read = readFor(smallShare < rightSizeWatchShare, "Right-sized")
+	} else {
+		r.Read = noDataRead
+	}
+	r.Purity = clamp01(1 - smallShare)
+	r.Figures = []Figure{
+		{Label: "premium turns", Value: strconv.FormatInt(premiumTurns, 10)},
+		{Label: "small-output premium", Value: shareOrDash(smallPremium, premiumTurns, 0), Note: "<" + strconv.Itoa(RightSizeSmallOutput) + " output tokens"},
+		{Label: "downgrade candidates", Value: strconv.FormatInt(smallPremium, 10), Note: "worth a cheaper/faster model"},
+	}
+	r.Takeaway = rightSizeTakeaway(enough, smallShare)
+	r.Caveats = []string{
+		"Task difficulty is invisible -- a short answer can still need the strong model. A prompt to review a few, not a verdict.",
+		"On a flat subscription this is about speed and rate limits, not dollar savings.",
+	}
+	return r
+}
+
+func rightSizeTakeaway(enough bool, smallShare float64) string {
+	switch {
+	case !enough:
+		return "Too few premium-model turns this window to judge right-sizing."
+	case smallShare >= rightSizeWatchShare:
+		return "A large share of premium-model turns produced little output -- worth trying a cheaper or faster model on routine work."
+	default:
+		return "Most premium-model turns produced substantial output -- the strong model is earning its use."
+	}
+}

--- a/internal/analyze/model_right_sizing_test.go
+++ b/internal/analyze/model_right_sizing_test.go
@@ -1,0 +1,29 @@
+package analyze
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+// TestModelRightSizingFlagsSmallPremiumTurns checks that a model whose premium turns are
+// mostly tiny-output reads as watch, with the small-output share reported. It reads the
+// per-turn TurnSizing counts (the daily Usage aggregate can't answer this), so the cheaper
+// model's turns must be ignored.
+func TestModelRightSizingFlagsSmallPremiumTurns(t *testing.T) {
+	in := BuildInput(nil, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	in.TurnSizing = []store.ModelTurns{
+		{Model: "claude-opus-4-5", Turns: 25, SmallTurns: 20},    // premium: 80% tiny
+		{Model: "claude-sonnet-4-5", Turns: 100, SmallTurns: 90}, // cheaper: ignored
+	}
+	got := mustGet(t, rightSizeName).Analyze(in)
+
+	if got.Read.Key != "watch" {
+		t.Fatalf("Read = %+v, want watch (most premium turns are tiny)", got.Read)
+	}
+	if !strings.Contains(figureValues(got.Figures), "80%") { // 20 of 25 premium small-output
+		t.Fatalf("Figures = %q, want 80%% small-output premium", figureValues(got.Figures))
+	}
+}

--- a/internal/analyze/prepared.go
+++ b/internal/analyze/prepared.go
@@ -11,7 +11,7 @@ type ModelStat struct {
 	// below premiumOutputPriceFloor is "cheaper"; a model absent from Prices is
 	// "unknown", never guessed from its name.
 	Tier string
-	// Tokens is In+Output+CacheRead+CacheWrite+Reasoning summed across this model's usage.
+	// Tokens is In+Output+CacheRead+CacheWrite summed (reasoning is a subset of output, not re-added) across this model's usage.
 	Tokens int64
 	// Input, Output, CacheRead, CacheWrite are the same usage summed per token type.
 	Input, Output, CacheRead, CacheWrite int64
@@ -47,7 +47,7 @@ type ProjectStat struct {
 // Totals is the queried window's grand totals across every model and project, computed
 // once by BuildInput so no validator re-sums Usage itself.
 type Totals struct {
-	// Tokens is In+Output+CacheRead+CacheWrite+Reasoning summed across all Usage.
+	// Tokens is In+Output+CacheRead+CacheWrite summed (reasoning is a subset of output, not re-added) across all Usage.
 	Tokens int64
 	// Input, Output, CacheRead, CacheWrite are the same usage summed per token type.
 	Input, Output, CacheRead, CacheWrite int64

--- a/internal/analyze/prepared_build.go
+++ b/internal/analyze/prepared_build.go
@@ -30,7 +30,6 @@ func BuildInput(usage []store.UsageRow, sessions []store.SessionRow, prices pric
 // row's model is unpriced.
 func buildTotals(rows []store.UsageRow, prices pricing.Table) Totals {
 	var t Totals
-	var reasoning int64
 	priced := len(rows) > 0
 	for i := range rows {
 		r := &rows[i]
@@ -39,7 +38,6 @@ func buildTotals(rows []store.UsageRow, prices pricing.Table) Totals {
 		t.CacheRead += r.CacheRead
 		t.CacheWrite += r.CacheWrite
 		t.Lines += r.LinesAdded
-		reasoning += r.Reasoning
 		if cost, ok := prices.CostTokens(r.Model, r.In, r.Out, r.CacheWrite, r.CacheRead); ok {
 			if t.Cost == nil {
 				zero := 0.0
@@ -50,7 +48,8 @@ func buildTotals(rows []store.UsageRow, prices pricing.Table) Totals {
 			priced = false
 		}
 	}
-	t.Tokens = t.Input + t.Output + t.CacheRead + t.CacheWrite + reasoning
+	// ReasoningTokens is a subset of OutputTokens (usage.Record); adding it double-counts.
+	t.Tokens = t.Input + t.Output + t.CacheRead + t.CacheWrite
 	t.Priced = priced
 	t.CacheEfficiency = fracOf(t.CacheRead, t.CacheRead+t.Input)
 	return t
@@ -76,7 +75,7 @@ func buildModelStats(rows []store.UsageRow, prices pricing.Table, totalTokens in
 		m.CacheRead += r.CacheRead
 		m.CacheWrite += r.CacheWrite
 		m.Lines += r.LinesAdded
-		m.Tokens += r.In + r.Out + r.CacheRead + r.CacheWrite + r.Reasoning
+		m.Tokens += r.In + r.Out + r.CacheRead + r.CacheWrite
 	}
 	sort.Strings(order)
 
@@ -119,7 +118,7 @@ func buildProjectStats(rows []store.UsageRow, prices pricing.Table, totalTokens 
 			order = append(order, r.Project)
 		}
 		a.stat.Lines += r.LinesAdded
-		a.tokens += r.In + r.Out + r.CacheRead + r.CacheWrite + r.Reasoning
+		a.tokens += r.In + r.Out + r.CacheRead + r.CacheWrite
 		if cost, ok := prices.CostTokens(r.Model, r.In, r.Out, r.CacheWrite, r.CacheRead); ok {
 			if a.stat.Cost == nil {
 				zero := 0.0

--- a/internal/analyze/prepared_test.go
+++ b/internal/analyze/prepared_test.go
@@ -32,7 +32,7 @@ func TestBuildInputByModelSumsClassifiesAndShares(t *testing.T) {
 	if len(in.ByModel) != 3 {
 		t.Fatalf("len(ByModel) = %d, want 3: %+v", len(in.ByModel), in.ByModel)
 	}
-	// Sorted by Tokens descending: cheap-model (6000) > premium-model (4160) > unknown-model (600).
+	// Sorted by Tokens descending: cheap-model (6000) > premium-model (4150) > unknown-model (600).
 	wantOrder := []string{"cheap-model", "premium-model", "unknown-model"}
 	for i, want := range wantOrder {
 		if got := in.ByModel[i].Model; got != want {
@@ -47,8 +47,8 @@ func TestBuildInputByModelSumsClassifiesAndShares(t *testing.T) {
 	if premium.Input != 1500 || premium.Output != 2500 || premium.CacheRead != 100 || premium.CacheWrite != 50 {
 		t.Fatalf("premium-model token breakdown = %+v, want In=1500 Out=2500 CacheRead=100 CacheWrite=50", premium)
 	}
-	if premium.Tokens != 4160 {
-		t.Fatalf("premium-model Tokens = %d, want 4160 (In+Out+CacheRead+CacheWrite+Reasoning)", premium.Tokens)
+	if premium.Tokens != 4150 {
+		t.Fatalf("premium-model Tokens = %d, want 4150 (In+Out+CacheRead+CacheWrite; reasoning is a subset of output)", premium.Tokens)
 	}
 	if premium.Lines != 50 {
 		t.Fatalf("premium-model Lines = %d, want 50", premium.Lines)
@@ -143,8 +143,8 @@ func TestBuildInputTotalsAndCacheEfficiency(t *testing.T) {
 	if tot.Input != 300 || tot.Output != 100 || tot.CacheRead != 300 || tot.CacheWrite != 20 {
 		t.Fatalf("Totals token breakdown = %+v, want In=300 Out=100 CacheRead=300 CacheWrite=20", tot)
 	}
-	if tot.Tokens != 725 {
-		t.Fatalf("Totals.Tokens = %d, want 725 (300+100+300+20+5 reasoning)", tot.Tokens)
+	if tot.Tokens != 720 {
+		t.Fatalf("Totals.Tokens = %d, want 720 (300+100+300+20; reasoning is a subset of output, not re-added)", tot.Tokens)
 	}
 	if tot.Lines != 14 {
 		t.Fatalf("Totals.Lines = %d, want 14", tot.Lines)

--- a/internal/analyze/reasoning_share.go
+++ b/internal/analyze/reasoning_share.go
@@ -1,0 +1,78 @@
+package analyze
+
+const (
+	reasoningName      = "reasoning-share"
+	reasoningTitle     = "Reasoning Share"
+	reasoningDescribe  = "How much generated output is extended-thinking (reasoning) tokens, among tools that report it -- flagging deep reasoning spent on shallow tasks."
+	reasoningHowToRead = "Reasoning tokens are billed as output. A high share means much of the model's work is internal deliberation, which can be overkill on routine tasks. Only some tools report reasoning (Codex and Gemini CLI today), so the coverage figure says how much of your output this even covers."
+	// reasoningWatchShare is the reasoning-of-output share above which the read flags heavy thinking.
+	reasoningWatchShare = 0.3
+)
+
+func init() { Register(reasoningValidator{}) }
+
+// reasoningValidator reports the reasoning share of output among tools that surface it, and
+// how much of the window's output that covers, so a Claude-heavy window reads honestly.
+type reasoningValidator struct{}
+
+func (reasoningValidator) Name() string     { return reasoningName }
+func (reasoningValidator) Title() string    { return reasoningTitle }
+func (reasoningValidator) Describe() string { return reasoningDescribe }
+
+//nolint:gocritic // Input is required by the Validator interface; analyzed once per run, not a hot path.
+func (reasoningValidator) Analyze(in Input) Result {
+	r := Result{Name: reasoningName, Title: reasoningTitle, Describe: reasoningDescribe, HowToRead: reasoningHowToRead}
+	if in.Totals.Output == 0 {
+		r.Read = noDataRead
+		r.Takeaway = "No output tokens in this window."
+		return r
+	}
+	var reasoning, reportingOutput int64
+	for i := range in.Usage {
+		u := &in.Usage[i]
+		if !reportsReasoning(u.Tool) {
+			continue
+		}
+		reasoning += u.Reasoning
+		reportingOutput += u.Out
+	}
+	if reportingOutput == 0 {
+		r.Read = noDataRead
+		r.Figures = []Figure{{Label: "reporting coverage", Value: "0%", Note: "no tool here reports reasoning"}}
+		r.Takeaway = "None of your tools reported reasoning tokens this window -- Claude Code doesn't surface them."
+		r.Caveats = []string{"Only Codex and Gemini CLI report reasoning tokens today; Claude Code doesn't."}
+		return r
+	}
+
+	// Share is of output from tools that actually report reasoning, so a Claude-heavy
+	// window (Claude doesn't surface it) isn't diluted to a meaningless near-zero.
+	share := fracOf(reasoning, reportingOutput)
+	coverage := fracOf(reportingOutput, in.Totals.Output)
+
+	r.Read = readFor(share < reasoningWatchShare, "Lean")
+	r.Purity = clamp01(1 - share)
+	r.Figures = []Figure{
+		{Label: "reasoning share", Value: honestPercent(share), Note: "of reporting output"},
+		{Label: "reasoning tokens", Value: compactCount(reasoning)},
+		{Label: "reporting coverage", Value: honestPercent(coverage), Note: "output from tools that report it"},
+	}
+	r.Takeaway = reasoningTakeaway(share)
+	r.Caveats = []string{
+		"Only Codex and Gemini CLI report reasoning tokens; Claude Code doesn't, so this covers part of your output.",
+		"Reasoning is a subset of output (already billed there); this is a composition signal, not extra cost.",
+	}
+	return r
+}
+
+// reportsReasoning reports whether tool's parser surfaces reasoning tokens today: Codex
+// (reasoning_output_tokens) and Gemini CLI (thoughts). Claude Code does not.
+func reportsReasoning(tool string) bool {
+	return tool == "codex" || tool == "gemini-cli"
+}
+
+func reasoningTakeaway(share float64) string {
+	if share >= reasoningWatchShare {
+		return "A large share of reported output is reasoning -- worth checking whether deep thinking is going to shallow tasks."
+	}
+	return "Reasoning is a modest share of reported output -- the thinking budget looks proportionate."
+}

--- a/internal/analyze/reasoning_share_test.go
+++ b/internal/analyze/reasoning_share_test.go
@@ -1,0 +1,26 @@
+package analyze
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+// TestReasoningShareUsesReportingToolsOnly checks that the reasoning share is taken over
+// output from tools that actually report reasoning (Codex), not diluted by Claude output
+// that never carries a reasoning count.
+func TestReasoningShareUsesReportingToolsOnly(t *testing.T) {
+	usage := []store.UsageRow{
+		{Day: "2026-07-10", Tool: "codex", Model: "gpt-x", Project: "p", In: 100, Out: 1000, Reasoning: 400},
+		{Day: "2026-07-10", Tool: "claude-code", Model: "claude-sonnet-4-5", Project: "p", In: 100, Out: 9000},
+	}
+	in := BuildInput(usage, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	got := mustGet(t, reasoningName).Analyze(in)
+
+	// 400 reasoning of 1000 Codex output -> 40%, not 400/10000 diluted by Claude.
+	if !strings.Contains(figureValues(got.Figures), "40%") {
+		t.Fatalf("Figures = %q, want 40%% reasoning share of reporting output", figureValues(got.Figures))
+	}
+}

--- a/internal/analyze/session_taxonomy.go
+++ b/internal/analyze/session_taxonomy.go
@@ -1,0 +1,100 @@
+package analyze
+
+import "strconv"
+
+const (
+	taxonomyName      = "session-taxonomy"
+	taxonomyTitle     = "Session Taxonomy"
+	taxonomyDescribe  = "What kind of work sessions are: conversational (no edits), light-edit, or heavy-edit, and how the mix splits."
+	taxonomyHowToRead = "Conversational sessions are real work -- design, debugging, and planning rarely touch files -- so a high conversational share is not waste. This is a mix, not a scorecard: read it to understand how you use AI, not to push every session toward edits."
+	// taxonomyLightMax is the top of the light-edit bucket (inclusive); above it is heavy.
+	taxonomyLightMax = 10
+	// taxonomyMinSessions is the floor below which the split is too thin to characterize.
+	taxonomyMinSessions = 5
+)
+
+func init() { Register(taxonomyValidator{}) }
+
+// taxonomyValidator buckets sessions by how much they edited: conversational (no edits),
+// light-edit, or heavy-edit -- a descriptive map of how AI is used, never a scorecard.
+type taxonomyValidator struct{}
+
+func (taxonomyValidator) Name() string     { return taxonomyName }
+func (taxonomyValidator) Title() string    { return taxonomyTitle }
+func (taxonomyValidator) Describe() string { return taxonomyDescribe }
+
+//nolint:gocritic // Input is required by the Validator interface; analyzed once per run, not a hot path.
+func (taxonomyValidator) Analyze(in Input) Result {
+	r := Result{Name: taxonomyName, Title: taxonomyTitle, Describe: taxonomyDescribe, HowToRead: taxonomyHowToRead}
+	if len(in.Sessions) == 0 {
+		r.Read = noDataRead
+		r.Takeaway = "No sessions in this window."
+		return r
+	}
+	var conv, light, heavy int64
+	for i := range in.Sessions {
+		switch e := in.Sessions[i].Edits; {
+		case e == 0:
+			conv++
+		case e <= taxonomyLightMax:
+			light++
+		default:
+			heavy++
+		}
+	}
+	total := int64(len(in.Sessions))
+	editing := light + heavy
+	enough := total >= taxonomyMinSessions
+
+	if enough {
+		r.Read = readFor(true, taxonomyLabel(conv, editing, total))
+	} else {
+		r.Read = noDataRead
+	}
+	r.Purity = fracOf(editing, total)
+	r.Figures = []Figure{
+		{Label: "conversational", Value: shareOrDash(conv, total, 0), Note: "no file edits"},
+		{Label: "light-edit", Value: shareOrDash(light, total, 0), Note: "1-" + strconv.Itoa(taxonomyLightMax) + " edits"},
+		{Label: "heavy-edit", Value: shareOrDash(heavy, total, 0), Note: ">" + strconv.Itoa(taxonomyLightMax) + " edits"},
+	}
+	r.Bars = []Bar{
+		taxonomyBar("conversational", conv, total),
+		taxonomyBar("light-edit", light, total),
+		taxonomyBar("heavy-edit", heavy, total),
+	}
+	r.Takeaway = taxonomyTakeaway(conv, editing, total, enough)
+	r.Caveats = []string{
+		"Conversational sessions are real work (design, debugging, planning) -- not idle time.",
+		"A thrash bucket needs per-session rework, which isn't stored yet, so it isn't split out here.",
+	}
+	return r
+}
+
+func taxonomyBar(label string, n, total int64) Bar {
+	return Bar{Label: label, Value: strconv.FormatInt(n, 10) + " (" + shareOrDash(n, total, 0) + ")", Frac: fracOf(n, total)}
+}
+
+// taxonomyLabel names the dominant bucket for the faceplate, short enough for the label slot.
+func taxonomyLabel(conv, editing, total int64) string {
+	switch {
+	case conv*2 > total:
+		return "Chat-led"
+	case editing*2 > total:
+		return "Edit-led"
+	default:
+		return "Mixed"
+	}
+}
+
+func taxonomyTakeaway(conv, editing, total int64, enough bool) string {
+	switch {
+	case !enough:
+		return "Too few sessions this window to characterize the mix."
+	case conv*2 > total:
+		return "Most sessions are conversational -- design and debugging work that rarely edits files."
+	case editing*2 > total:
+		return "Most sessions produce edits -- AI is doing hands-on building here."
+	default:
+		return "A balanced mix of conversational and edit-producing sessions."
+	}
+}

--- a/internal/analyze/session_taxonomy_test.go
+++ b/internal/analyze/session_taxonomy_test.go
@@ -1,0 +1,30 @@
+package analyze
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+// TestSessionTaxonomyBucketsByEdits checks the conversational/light/heavy split and that a
+// conversational-majority window reads as chat-led (design/debug work), not waste.
+func TestSessionTaxonomyBucketsByEdits(t *testing.T) {
+	sessions := []store.SessionRow{
+		{SessionID: "a", Edits: 0, Turns: 3},
+		{SessionID: "b", Edits: 0, Turns: 2},
+		{SessionID: "c", Edits: 0, Turns: 1},
+		{SessionID: "d", Edits: 3, Turns: 5},
+		{SessionID: "e", Edits: 25, Turns: 12},
+	}
+	in := BuildInput(nil, sessions, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	got := mustGet(t, taxonomyName).Analyze(in)
+
+	if !strings.Contains(figureValues(got.Figures), "60%") { // 3 of 5 conversational
+		t.Fatalf("Figures = %q, want 60%% conversational", figureValues(got.Figures))
+	}
+	if !strings.Contains(got.Takeaway, "conversational") {
+		t.Fatalf("Takeaway = %q, want the chat-led message", got.Takeaway)
+	}
+}

--- a/internal/analyze/subscription.go
+++ b/internal/analyze/subscription.go
@@ -1,0 +1,148 @@
+package analyze
+
+import (
+	"strconv"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+const (
+	subscriptionName      = "subscription-fit"
+	subscriptionTitle     = "Subscription Fit"
+	subscriptionDescribe  = "Whether a flat monthly plan (Claude Max/Pro, ChatGPT Plus/Pro) pays off vs API pay-as-you-go, from your configured plan cost."
+	subscriptionHowToRead = "This projects your window's API-equivalent cost to a month at your active-day pace, then compares it against the flat plan price you configured. A high multiple means the plan is a bargain at your volume; below 1x means API pay-as-you-go might be cheaper. The API figure is an estimate at public prices, not your actual bill."
+	// monthDays is the active-day count the per-day API-equivalent rate is projected onto.
+	monthDays = 30
+)
+
+// planUnsetRead is the neutral faceplate shown when usage exists but no plan cost is
+// configured -- the validator still appears, prompting the user to set one.
+var planUnsetRead = Read{Key: "neutral", Label: "SET PLAN"}
+
+func init() { Register(subscriptionValidator{}) }
+
+// subscriptionValidator answers "is my flat subscription worth it?" by comparing the
+// window's API-equivalent estimate (projected to a month) against the configured plan cost.
+// It is the honest resolution to the estimate-vs-bill gap: a subscription user's
+// API-equivalent $ is meaningless as a spend figure but very meaningful as plan value.
+type subscriptionValidator struct{}
+
+func (subscriptionValidator) Name() string     { return subscriptionName }
+func (subscriptionValidator) Title() string    { return subscriptionTitle }
+func (subscriptionValidator) Describe() string { return subscriptionDescribe }
+
+//nolint:gocritic // Input is a small value bundle required by the Validator interface; analyzed once per CLI run, not a hot path.
+func (subscriptionValidator) Analyze(in Input) Result {
+	r := Result{Name: subscriptionName, Title: subscriptionTitle, Describe: subscriptionDescribe, HowToRead: subscriptionHowToRead}
+	if in.Totals.Tokens == 0 {
+		r.Read = noDataRead
+		r.Takeaway = "No usage in this window."
+		return r
+	}
+
+	apiMonthly, priced := projectedMonthlyCost(&in)
+	if in.PlanMonthlyCost <= 0 {
+		r.Read = planUnsetRead
+		if priced {
+			r.Figures = []Figure{{Label: "API-equivalent", Value: "~$" + money(apiMonthly) + "/mo", Note: "projected estimate"}}
+		}
+		r.Takeaway = "Set config.pricing.monthly_subscription_cost to see whether your flat plan beats API pricing at this volume."
+		r.Caveats = []string{"The API-equivalent $ is an estimate at public pay-as-you-go prices, not your actual bill."}
+		return r
+	}
+	if !priced {
+		r.Read = noDataRead
+		r.Takeaway = "No priced usage this window to compare against the plan."
+		return r
+	}
+
+	multiple := apiMonthly / in.PlanMonthlyCost
+	payingOff := multiple >= 1
+	r.Read = readFor(payingOff, "Paying off")
+	r.Purity = clamp01(multiple / 2)
+	r.Figures = []Figure{
+		{Label: "plan cost", Value: "$" + money(in.PlanMonthlyCost) + "/mo", Note: "configured flat rate"},
+		{Label: "API-equivalent", Value: "~$" + money(apiMonthly) + "/mo", Note: "projected estimate"},
+		{Label: "value multiple", Value: valueMultiple(multiple), Note: "API-equiv / plan"},
+		{Label: "vs API", Value: signedMoney(apiMonthly-in.PlanMonthlyCost) + "/mo", Note: savingsNote(payingOff)},
+	}
+	r.Takeaway = subscriptionTakeaway(payingOff, multiple)
+	r.Caveats = []string{
+		"The API-equivalent $ is an estimate at public pay-as-you-go prices, not your actual bill.",
+		"Projected to a month from this window's usage, and it excludes any unpriced-model usage.",
+	}
+	return r
+}
+
+// projectedMonthlyCost scales the window's API-equivalent cost to a month at the observed
+// per-active-day rate, so a sparse or partial window isn't compared against a full month's
+// plan price at face value (which would under-report a heavy-but-recent user). priced is
+// false when nothing in the window had a known price. Same active-day-pace convention as
+// model-fit savings.
+func projectedMonthlyCost(in *Input) (cost float64, priced bool) {
+	if in.Totals.Cost == nil {
+		return 0, false
+	}
+	days := distinctActiveDays(in.Usage)
+	if days <= 0 {
+		return *in.Totals.Cost, true
+	}
+	return *in.Totals.Cost / float64(days) * monthDays, true
+}
+
+// distinctActiveDays counts the distinct UTC calendar days ("YYYY-MM-DD") the window's usage
+// spans -- the denominator for the per-active-day run-rate projection.
+func distinctActiveDays(rows []store.UsageRow) int {
+	seen := make(map[string]struct{})
+	for i := range rows {
+		if rows[i].Day != "" {
+			seen[rows[i].Day] = struct{}{}
+		}
+	}
+	return len(seen)
+}
+
+func subscriptionTakeaway(payingOff bool, multiple float64) string {
+	switch {
+	case multiple >= 3:
+		return "Your flat plan returns ~" + valueMultiple(multiple) + " its price in API-equivalent usage -- it is paying off handily."
+	case payingOff:
+		return "Your flat plan is worth ~" + valueMultiple(multiple) + " its price in API-equivalent usage -- it pays off."
+	default:
+		return "Your API-equivalent usage is below the plan price this window -- at this volume, API pay-as-you-go could be cheaper."
+	}
+}
+
+// money renders a dollar amount compactly: 195 -> "195", 26004 -> "26.0K".
+func money(v float64) string {
+	switch {
+	case v >= 10_000:
+		return strconv.FormatFloat(v/1000, 'f', 1, 64) + "K"
+	case v >= 100:
+		return strconv.FormatFloat(v, 'f', 0, 64)
+	default:
+		return strconv.FormatFloat(v, 'f', 2, 64)
+	}
+}
+
+func signedMoney(v float64) string {
+	if v >= 0 {
+		return "+$" + money(v)
+	}
+	return "-$" + money(-v)
+}
+
+// valueMultiple renders the API-equiv/plan ratio: "134x", or "2.3x" below ten.
+func valueMultiple(m float64) string {
+	if m >= 10 {
+		return strconv.FormatFloat(m, 'f', 0, 64) + "x"
+	}
+	return strconv.FormatFloat(m, 'f', 1, 64) + "x"
+}
+
+func savingsNote(payingOff bool) string {
+	if payingOff {
+		return "saved vs API"
+	}
+	return "over API cost"
+}

--- a/internal/analyze/subscription_test.go
+++ b/internal/analyze/subscription_test.go
@@ -1,0 +1,48 @@
+package analyze
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+// TestSubscriptionFitComparesPlanToApiEquivalent covers the paying-off path: with a plan
+// cost configured, the validator projects the window's API-equivalent to a month and reports
+// the value multiple -- the honest reframe of a raw estimate that is meaningless as spend.
+func TestSubscriptionFitComparesPlanToApiEquivalent(t *testing.T) {
+	usage := []store.UsageRow{
+		{Day: "2026-07-10", Tool: "claude-code", Model: "claude-sonnet-4-5", Project: "web", In: 10_000_000, Out: 100_000_000},
+	}
+	in := BuildInput(usage, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	in.PlanMonthlyCost = 195 // one active day of ~$1530 projects to ~$45.9K/mo vs a $195 plan
+
+	got := mustGet(t, subscriptionName).Analyze(in)
+	if got.Read.Key != "good" {
+		t.Fatalf("Read = %+v, want a good (paying-off) read", got.Read)
+	}
+	joined := figureValues(got.Figures)
+	if !strings.Contains(joined, "195") {
+		t.Fatalf("Figures = %q, want the $195 plan cost", joined)
+	}
+	if !strings.Contains(joined, "x") {
+		t.Fatalf("Figures = %q, want a value multiple like 7.8x", joined)
+	}
+	if !strings.Contains(got.Takeaway, "pay") {
+		t.Fatalf("Takeaway = %q, want a paying-off message", got.Takeaway)
+	}
+}
+
+// TestSubscriptionFitPromptsWhenUnconfigured covers the default state: with no plan cost
+// configured, the validator still appears but prompts the user to set one.
+func TestSubscriptionFitPromptsWhenUnconfigured(t *testing.T) {
+	usage := []store.UsageRow{
+		{Day: "2026-07-10", Tool: "claude-code", Model: "claude-sonnet-4-5", Project: "web", In: 1000, Out: 1000},
+	}
+	in := BuildInput(usage, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	got := mustGet(t, subscriptionName).Analyze(in)
+	if !strings.Contains(got.Takeaway, "monthly_subscription_cost") {
+		t.Fatalf("Takeaway = %q, want a prompt to configure the plan cost", got.Takeaway)
+	}
+}

--- a/internal/analyze/throughput.go
+++ b/internal/analyze/throughput.go
@@ -1,13 +1,9 @@
 package analyze
 
 import (
-	"sort"
 	"strconv"
-	"time"
 
-	"github.com/assaio/assaio/internal/pricing"
 	"github.com/assaio/assaio/internal/report"
-	"github.com/assaio/assaio/internal/store"
 )
 
 const (
@@ -57,7 +53,7 @@ func (throughputValidator) Analyze(in Input) Result {
 		{Label: "lines/active-day", Value: perActiveDay(in.Totals.Lines, int64(inv.Days))},
 		trendFigure(recent, prior, changePct, trendOK),
 	}
-	r.Bars = topProjectsByLines(in.Usage, in.Prices, in.Now, in.Recent, throughputTopN)
+	r.Bars = topProjectBars(in.ByProject, throughputTopN)
 	r.BarsAreProjects = true
 	r.Takeaway = throughputTakeaway(ramping, growthSignal && !sufficientVolume)
 	return r
@@ -74,25 +70,31 @@ func throughputTakeaway(ramping, trendUpButTrivial bool) string {
 	}
 }
 
-// topProjectsByLines ranks the recent-window projects by AI-added lines descending, not
-// cost, so the bars' visual order matches the lines each one shows -- a project with
-// fewer lines never outranks one with more just because it cost more. topN <= 0 is
-// unlimited.
-func topProjectsByLines(rows []store.UsageRow, prices pricing.Table, now time.Time, window time.Duration, topN int) []Bar {
-	// "project" is a hardcoded valid dimension; the error return is unreachable here.
-	projects, _ := report.BuildEffectiveness(recentRows(rows, now, window), prices, "project")
-	sort.SliceStable(projects, func(i, j int) bool { return projects[i].LinesAdded > projects[j].LinesAdded })
-	if topN > 0 && len(projects) > topN {
-		projects = projects[:topN]
+// topProjectBars renders the whole-window top projects by AI-added lines, so the bars
+// break down the same window as the "AI lines total" figure above them rather than a
+// recent-only sub-window. in.ByProject is already sorted by Lines descending, so its
+// first entry is the max used to scale Frac. topN <= 0 is unlimited.
+func topProjectBars(projects []ProjectStat, topN int) []Bar {
+	kept := make([]ProjectStat, 0, len(projects))
+	for i := range projects {
+		if projects[i].Lines > 0 { // a "top projects by lines" list shouldn't pad with 0-line rows
+			kept = append(kept, projects[i])
+		}
 	}
-
+	if topN > 0 && len(kept) > topN {
+		kept = kept[:topN]
+	}
 	var maxLines int64
-	if len(projects) > 0 {
-		maxLines = projects[0].LinesAdded
+	if len(kept) > 0 {
+		maxLines = kept[0].Lines
 	}
-	bars := make([]Bar, len(projects))
-	for i, p := range projects {
-		bars[i] = Bar{Label: groupLabel(p.Group), Value: strconv.FormatInt(p.LinesAdded, 10) + " lines", Frac: fracOf(p.LinesAdded, maxLines)}
+	bars := make([]Bar, len(kept))
+	for i := range kept {
+		bars[i] = Bar{
+			Label: groupLabel(kept[i].Project),
+			Value: strconv.FormatInt(kept[i].Lines, 10) + " lines",
+			Frac:  fracOf(kept[i].Lines, maxLines),
+		}
 	}
 	return bars
 }

--- a/internal/analyze/trend.go
+++ b/internal/analyze/trend.go
@@ -47,20 +47,6 @@ func weekOverWeek(rows []store.UsageRow, now time.Time, window time.Duration) (r
 	return recent, prior, float64(recent-prior) / float64(prior), true
 }
 
-// recentRows returns the rows on or after now-window -- the same recent sub-window
-// weekOverWeek sums -- for a validator that needs the recent rows themselves, not just
-// their LinesAdded total.
-func recentRows(rows []store.UsageRow, now time.Time, window time.Duration) []store.UsageRow {
-	cutoff := recentCutoff(now, window)
-	out := make([]store.UsageRow, 0, len(rows))
-	for i := range rows {
-		if rows[i].Day >= cutoff {
-			out = append(out, rows[i])
-		}
-	}
-	return out
-}
-
 // trendLabel renders a week-over-week change as "+35%", "-12%", or "—" when undefined.
 func trendLabel(changePct float64, ok bool) string {
 	if !ok {

--- a/internal/analyze/turn_efficiency.go
+++ b/internal/analyze/turn_efficiency.go
@@ -1,0 +1,93 @@
+package analyze
+
+import (
+	"sort"
+	"strconv"
+)
+
+const (
+	turnEffName      = "turn-efficiency"
+	turnEffTitle     = "Turn Efficiency"
+	turnEffDescribe  = "Getting more per prompt: one-shot rate, median turns per code-producing session, and output tokens per turn."
+	turnEffHowToRead = "These are prompting-efficiency signals, not quality. A session that lands an edit in a turn or two is efficient; a long session can be deliberate, careful work. Task size is invisible here, so read it directionally, never as a per-person score."
+	// turnEffOneShotMax is the turn count at or below which a code-producing session is one-shot.
+	turnEffOneShotMax = 2
+	// turnEffGoodOneShot is the one-shot rate above which prompting reads as efficient.
+	turnEffGoodOneShot = 0.25
+	// turnEffMinCodeSessions is the floor below which the one-shot rate is too thin to judge.
+	turnEffMinCodeSessions = 5
+)
+
+func init() { Register(turnEffValidator{}) }
+
+// turnEffValidator measures prompting efficiency over code-producing sessions: how often a
+// result lands in one or two turns, the median turns it takes, and output produced per turn.
+type turnEffValidator struct{}
+
+func (turnEffValidator) Name() string     { return turnEffName }
+func (turnEffValidator) Title() string    { return turnEffTitle }
+func (turnEffValidator) Describe() string { return turnEffDescribe }
+
+//nolint:gocritic // Input is required by the Validator interface; analyzed once per run, not a hot path.
+func (turnEffValidator) Analyze(in Input) Result {
+	r := Result{Name: turnEffName, Title: turnEffTitle, Describe: turnEffDescribe, HowToRead: turnEffHowToRead}
+	var codeSessions, oneShot int64
+	var codeTurns, outPerTurn []float64
+	for i := range in.Sessions {
+		s := &in.Sessions[i]
+		if s.Edits == 0 {
+			continue
+		}
+		codeSessions++
+		codeTurns = append(codeTurns, float64(s.Turns))
+		if s.Turns <= turnEffOneShotMax {
+			oneShot++
+		}
+		if s.Turns > 0 {
+			outPerTurn = append(outPerTurn, float64(s.OutputTokens)/float64(s.Turns))
+		}
+	}
+	if codeSessions == 0 {
+		r.Read = noDataRead
+		r.Takeaway = "No code-producing sessions in this window."
+		return r
+	}
+	enough := codeSessions >= turnEffMinCodeSessions
+	oneShotRate := fracOf(oneShot, codeSessions)
+	sort.Float64s(codeTurns)
+
+	if enough {
+		r.Read = readFor(oneShotRate >= turnEffGoodOneShot, "Efficient")
+	} else {
+		r.Read = noDataRead
+	}
+	r.Purity = clamp01(oneShotRate)
+	r.Figures = []Figure{
+		{Label: "one-shot rate", Value: honestPercent(oneShotRate), Note: "code sessions in <=" + strconv.Itoa(turnEffOneShotMax) + " turns"},
+		{Label: "median turns", Value: strconv.FormatFloat(medianAt50(codeTurns), 'f', 0, 64), Note: "per code session"},
+		{Label: "output/turn", Value: medianOutputPerTurn(outPerTurn), Note: "median tokens"},
+	}
+	r.Takeaway = turnEffTakeaway(enough, oneShotRate)
+	r.Caveats = []string{"Task size is invisible in logs, so a low one-shot rate can mean hard problems, not weak prompting -- directional only."}
+	return r
+}
+
+// medianOutputPerTurn renders the median output-tokens-per-turn, or "—" when no session had turns.
+func medianOutputPerTurn(outPerTurn []float64) string {
+	if len(outPerTurn) == 0 {
+		return "—"
+	}
+	sort.Float64s(outPerTurn)
+	return compactCount(int64(medianAt50(outPerTurn)))
+}
+
+func turnEffTakeaway(enough bool, oneShotRate float64) string {
+	switch {
+	case !enough:
+		return "Too few code-producing sessions this window to judge prompting efficiency."
+	case oneShotRate >= turnEffGoodOneShot:
+		return "A healthy share of code sessions land in one or two turns."
+	default:
+		return "Most code sessions take several turns -- could be hard problems, or room to prompt more precisely."
+	}
+}

--- a/internal/analyze/turn_efficiency_test.go
+++ b/internal/analyze/turn_efficiency_test.go
@@ -1,0 +1,29 @@
+package analyze
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assaio/assaio/internal/store"
+)
+
+// TestTurnEfficiencyOneShotRate checks the one-shot rate over code-producing sessions:
+// conversational sessions are excluded, and only Turns <= 2 count as one-shot.
+func TestTurnEfficiencyOneShotRate(t *testing.T) {
+	sessions := []store.SessionRow{
+		{SessionID: "a", Edits: 2, Turns: 1, OutputTokens: 500},
+		{SessionID: "b", Edits: 1, Turns: 2, OutputTokens: 800},
+		{SessionID: "c", Edits: 5, Turns: 10, OutputTokens: 3000},
+		{SessionID: "d", Edits: 3, Turns: 8, OutputTokens: 1600},
+		{SessionID: "e", Edits: 4, Turns: 6, OutputTokens: 1200},
+		{SessionID: "f", Edits: 0, Turns: 3, OutputTokens: 100}, // conversational: ignored
+	}
+	in := BuildInput(nil, sessions, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
+	got := mustGet(t, turnEffName).Analyze(in)
+
+	// 5 code sessions, 2 one-shot -> 40%.
+	if !strings.Contains(figureValues(got.Figures), "40%") {
+		t.Fatalf("Figures = %q, want a 40%% one-shot rate", figureValues(got.Figures))
+	}
+}

--- a/internal/analyze/validators_test.go
+++ b/internal/analyze/validators_test.go
@@ -190,22 +190,22 @@ func TestAdoptionBroadButFlatTakeaway(t *testing.T) {
 	}
 }
 
-// TestThroughputEmptyBarsWhenNoRecentUsage covers the honest empty state when a window's
-// usage never lands in the recent sub-window: Bars must be present-but-empty, rendering
-// "(none in this window)" rather than silently showing nothing.
-func TestThroughputEmptyBarsWhenNoRecentUsage(t *testing.T) {
+// TestThroughputBarsCoverWholeWindowMatchingTotal locks in the window-consistency fix:
+// the top-project bars break down the whole-window "AI lines total" figure, so usage
+// outside the recent trend sub-window still shows in the bars instead of the total and
+// the bars silently covering different windows.
+func TestThroughputBarsCoverWholeWindowMatchingTotal(t *testing.T) {
 	usage := []store.UsageRow{
 		{Day: "2026-06-01", Tool: "claude-code", Model: "claude-sonnet-4-5", Project: "old", In: 10, Out: 10, LinesAdded: 5},
 	}
 	in := BuildInput(usage, nil, testPrices(), validatorsTestNow, 7*24*time.Hour, Delegation{})
 	v, _ := Get("throughput")
-	var buf bytes.Buffer
-	if err := RenderResultText(&buf, v.Analyze(in)); err != nil {
-		t.Fatal(err)
+	got := v.Analyze(in)
+	if len(got.Bars) != 1 || got.Bars[0].Label != "old" {
+		t.Fatalf("Bars = %+v, want one bar for the in-window project 'old'", got.Bars)
 	}
-	out := buf.String()
-	if !strings.Contains(out, "(none in this window)") {
-		t.Fatalf("throughput output with no recent usage = %q", out)
+	if !strings.Contains(got.Bars[0].Value, "5") {
+		t.Fatalf("Bars[0].Value = %q, want the 5 whole-window lines matching the total", got.Bars[0].Value)
 	}
 }
 

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -88,13 +88,14 @@ func runAnalyze(cmd *cobra.Command, names []string, since *string, format string
 		return err
 	}
 	if n == 0 && format == "text" {
-		return report.RenderEmptyStatusHint(cmd.OutOrStdout())
+		return emptyStatusHint(cmd)
 	}
 
 	in, err := buildAnalyzeInput(cmd, st, start)
 	if err != nil {
 		return err
 	}
+	in.PlanMonthlyCost = cfg.Pricing.MonthlySubscriptionCost
 	results, err := collectAnalysisResults(cmd, names, cfg.Metrics, &in)
 	if err != nil {
 		return err
@@ -119,7 +120,13 @@ func buildAnalyzeInput(cmd *cobra.Command, st *store.Store, start time.Time) (an
 	if err != nil {
 		return analyze.Input{}, err
 	}
-	return analyze.BuildInput(usageRows, sessionRows, table, time.Now(), analyzeRecentWindow, analyze.Delegation{Sub: sub, Total: total}), nil
+	turns, err := st.TurnSizing(cmd.Context(), start, analyze.RightSizeSmallOutput)
+	if err != nil {
+		return analyze.Input{}, err
+	}
+	in := analyze.BuildInput(usageRows, sessionRows, table, time.Now(), analyzeRecentWindow, analyze.Delegation{Sub: sub, Total: total})
+	in.TurnSizing = turns
+	return in, nil
 }
 
 func renderAnalyzeResults(cmd *cobra.Command, results []analyze.Result, format string) error {

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -32,8 +32,8 @@ func TestAnalyzeList(t *testing.T) {
 			t.Fatalf("analyze --list missing %q: %s", want, s)
 		}
 	}
-	if got := strings.Count(s, "\n"); got != 5 {
-		t.Fatalf("analyze --list must print exactly 5 lines, got %d: %s", got, s)
+	if got := strings.Count(s, "\n"); got != 12 {
+		t.Fatalf("analyze --list must print exactly 12 lines, got %d: %s", got, s)
 	}
 }
 
@@ -183,8 +183,8 @@ func TestAnalyzeFormatJSONIsValidJSON(t *testing.T) {
 	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
 		t.Fatalf("analyze --format json produced invalid JSON: %v\n%s", err, out.String())
 	}
-	if len(decoded) != 5 {
-		t.Fatalf("json output has %d entries, want 5: %s", len(decoded), out.String())
+	if len(decoded) != 12 {
+		t.Fatalf("json output has %d entries, want 12: %s", len(decoded), out.String())
 	}
 	gotNames := make(map[string]bool, len(decoded))
 	for _, r := range decoded {
@@ -357,8 +357,8 @@ func TestAnalyzeListShowsMetricPluginsWithoutRunning(t *testing.T) {
 	if !strings.Contains(out, "plugin:demo") || !strings.Contains(out, "exec metric plugin") {
 		t.Fatalf("--list missing configured metric plugin:\n%s", out)
 	}
-	if got := strings.Count(out, "\n"); got != 6 {
-		t.Fatalf("--list must print 5 built-ins + 1 plugin = 6 lines, got %d:\n%s", got, out)
+	if got := strings.Count(out, "\n"); got != 13 {
+		t.Fatalf("--list must print 12 built-ins + 1 plugin = 13 lines, got %d:\n%s", got, out)
 	}
 	if _, err := os.Stat(metricRanSentinel(script)); err == nil {
 		t.Fatal("--list must never execute metric plugins")

--- a/internal/cli/backfill.go
+++ b/internal/cli/backfill.go
@@ -36,7 +36,7 @@ func runBackfill(cmd *cobra.Command) error {
 		return err
 	}
 	defer func() { _ = st.Close() }()
-	cfg, err := loadConfig(cmd)
+	cfg, err := loadConfigLenient(cmd)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/clear.go
+++ b/internal/cli/clear.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -32,6 +34,12 @@ func runClear(cmd *cobra.Command, all, yes bool, olderThan, tool string) error {
 	if !all && olderThan == "" && tool == "" {
 		return errors.New("specify --all, --older-than, or --tool")
 	}
+	if all && (olderThan != "" || tool != "") {
+		return errors.New("--all cannot be combined with --older-than or --tool")
+	}
+	if tool != "" && !validClearTool(tool) {
+		return fmt.Errorf("unknown tool %q (want claude-code|codex|gemini-cli|cline|plugin:<name>)", tool)
+	}
 	if !yes {
 		return errors.New("refusing to delete without --yes")
 	}
@@ -57,6 +65,18 @@ func runClear(cmd *cobra.Command, all, yes bool, olderThan, tool string) error {
 	}
 	cmd.Printf("deleted %d record(s)\n", n)
 	return nil
+}
+
+// validClearTool reports whether tool is a stored tool name clear can target: a built-in
+// source or an out-of-tree plugin's "plugin:<name>" namespace. Rejecting anything else
+// stops a typo (e.g. "claude" for "claude-code") from silently deleting nothing while
+// reporting success.
+func validClearTool(tool string) bool {
+	switch tool {
+	case "claude-code", "codex", "gemini-cli", "cline":
+		return true
+	}
+	return strings.HasPrefix(tool, "plugin:") && len(tool) > len("plugin:")
 }
 
 // clearCutoff resolves --older-than to a cutoff time, or the zero time when unset.

--- a/internal/cli/clear_test.go
+++ b/internal/cli/clear_test.go
@@ -78,3 +78,40 @@ func TestClearRequiresYes(t *testing.T) {
 		t.Fatalf("error = %q", err)
 	}
 }
+
+// TestClearRejectsUnknownTool guards against a typo silently deleting nothing while
+// reporting success: "claude" is not the stored tool name "claude-code".
+func TestClearRejectsUnknownTool(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"clear", "--tool", "claude", "--yes"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for an unknown --tool value")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Fatalf("error = %q, want an unknown-tool error", err)
+	}
+}
+
+// TestClearRejectsAllCombinedWithScope guards the contradictory invocation where --all
+// (delete everything) is silently narrowed by --older-than/--tool, leaving data the user
+// believed was purged.
+func TestClearRejectsAllCombinedWithScope(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"clear", "--all", "--tool", "codex", "--yes"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when --all is combined with --tool")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("error = %q, want a contradiction error", err)
+	}
+}

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -10,7 +10,7 @@ func newConfigCmd() *cobra.Command {
 		Short: "Show the effective configuration",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cfg, err := loadConfig(cmd)
+			cfg, err := loadConfigRaw(cmd)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -36,3 +36,25 @@ func TestConfigShowWarnsOnInvalidFormat(t *testing.T) {
 		t.Fatalf("config output = %q, want a warning line", out.String())
 	}
 }
+
+// TestReportEnforcesConfigValidation is the counterpart to the warn-only `config` behavior
+// above: every other command refuses to run on an invalid config, so an honesty-relevant
+// typo (here an invalid format, standing in for a misspelled pricing.mode) can't silently
+// apply with reports carrying on as if the setting were valid.
+func TestReportEnforcesConfigValidation(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	t.Setenv("ASSAIO_FORMAT", "bogus")
+	root := NewRootCmd()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"report"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected report to reject an invalid config value")
+	}
+	if !strings.Contains(err.Error(), "invalid format") {
+		t.Fatalf("error = %q, want an invalid-format validation error", err)
+	}
+}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -61,13 +61,14 @@ func runDashboard(cmd *cobra.Command, since, output *string) error {
 		return err
 	}
 	if n == 0 {
-		cmd.Println(emptyStoreHint(cmd, "No usage yet."))
+		cmd.Println(emptyStoreHint(cmd, "No usage yet; writing an empty dashboard."))
 	}
 
 	in, err := buildAnalyzeInput(cmd, st, start)
 	if err != nil {
 		return err
 	}
+	in.PlanMonthlyCost = cfg.Pricing.MonthlySubscriptionCost
 	subpaths, err := loadDrillSubpaths(cmd, st, &in, start)
 	if err != nil {
 		return err

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -27,7 +27,7 @@ func newDoctorCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			cfg, err := loadConfig(cmd)
+			cfg, err := loadConfigLenient(cmd)
 			if err != nil {
 				return err
 			}
@@ -52,7 +52,11 @@ func newDoctorCmd() *cobra.Command {
 				return nil
 			}
 			defer func() { _ = st.Close() }()
-			n, _ := st.Count(cmd.Context())
+			n, err := st.Count(cmd.Context())
+			if err != nil {
+				cmd.Printf("store:        ERROR counting records: %v\n", err)
+				return nil
+			}
 			cmd.Printf("store:        ok, %d record(s) at %s\n", n, dbPath)
 			cmd.Printf("inventory:    %s\n", doctorInventoryLabel(cmd, st, n))
 

--- a/internal/cli/effectiveness.go
+++ b/internal/cli/effectiveness.go
@@ -43,6 +43,9 @@ func runEffectiveness(cmd *cobra.Command, since, format *string, by string) erro
 	}
 	defer func() { _ = st.Close() }()
 	if compare, _ := cmd.Flags().GetBool("compare"); compare {
+		if err := compareFormatConflict(cmd); err != nil {
+			return err
+		}
 		return runCompare(cmd, st, *since, by)
 	}
 	built, err := buildEffectiveness(cmd, st, start, by)
@@ -68,7 +71,7 @@ func renderEffectiveness(cmd *cobra.Command, built []report.EffRow, format, by s
 	switch format {
 	case "table":
 		if len(built) == 0 {
-			cmd.Println("No usage found. Run 'assaio-agent backfill' to import your local session logs.")
+			cmd.Println(emptyStoreHint(cmd, "No usage found."))
 			return nil
 		}
 		return report.RenderEffectivenessTable(cmd.OutOrStdout(), built, by)

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -48,6 +48,9 @@ func runReport(cmd *cobra.Command, since, format *string, by string) error {
 	}
 	defer func() { _ = st.Close() }()
 	if compare, _ := cmd.Flags().GetBool("compare"); compare {
+		if err := compareFormatConflict(cmd); err != nil {
+			return err
+		}
 		return runCompare(cmd, st, *since, by)
 	}
 	built, err := buildReport(cmd, st, start, by)
@@ -128,6 +131,31 @@ func emptyStoreHint(cmd *cobra.Command, prefix string) string {
 		return prefix + " This store has no usage records."
 	}
 	return prefix + " Run 'assaio-agent backfill' to import your local session logs."
+}
+
+// compareFormatConflict errors when --compare is combined with an explicit machine format:
+// --compare only renders a human movers table, so a scripted `--format json|csv` consumer
+// would otherwise get a table with no error. A format inherited from config (not set on
+// the command line) is left alone, since --compare then just renders its table.
+func compareFormatConflict(cmd *cobra.Command) error {
+	if !cmd.Flags().Changed("format") {
+		return nil
+	}
+	if f, _ := cmd.Flags().GetString("format"); f == "json" || f == "csv" {
+		return errors.New("--compare renders a movers table and cannot be combined with --format json|csv")
+	}
+	return nil
+}
+
+// emptyStatusHint writes the store-empty message for status/analyze, db-aware like
+// emptyStoreHint: the rich backfill suggestion for the local store, or a terse "this store
+// has no records" when --db points at a central store backfill cannot populate.
+func emptyStatusHint(cmd *cobra.Command) error {
+	if cmd.Flags().Changed("db") {
+		cmd.Println(emptyStoreHint(cmd, "No usage found."))
+		return nil
+	}
+	return report.RenderEmptyStatusHint(cmd.OutOrStdout())
 }
 
 func openReportStore(cmd *cobra.Command) (*store.Store, error) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -34,7 +34,7 @@ are never read. The optional team server (serve/sync) is self-hosted and opt-in.
 	root.PersistentFlags().String("config", "", "config file path")
 	root.AddCommand(newVersionCmd(), newDemoCmd(), newReportCmd(), newEffectivenessCmd(), newAnalyzeCmd(), newCheckCmd(),
 		newDashboardCmd(), newBackfillCmd(), newDoctorCmd(), newStatusCmd(), newClearCmd(), newConfigCmd(), newPluginsCmd(),
-		newMetricsCmd(), newServeCmd(), newSyncCmd())
+		newMetricsCmd(), newServeCmd(), newSyncCmd(), newSurvivalCmd())
 	return root
 }
 
@@ -42,7 +42,8 @@ func ensureParent(path string) error {
 	return os.MkdirAll(filepath.Dir(path), 0o750)
 }
 
-func loadConfig(cmd *cobra.Command) (config.Config, error) {
+// loadConfigRaw resolves the config path and loads the merged config WITHOUT validating it.
+func loadConfigRaw(cmd *cobra.Command) (config.Config, error) {
 	path, explicit, err := configPath(cmd)
 	if err != nil {
 		return config.Config{}, err
@@ -55,6 +56,35 @@ func loadConfig(cmd *cobra.Command) (config.Config, error) {
 		}
 	}
 	return config.Load(path)
+}
+
+// loadConfig loads the merged config and REJECTS an invalid one, so a typo in an
+// honesty-relevant setting (a misspelled pricing.mode, a duplicate plugin name) can't
+// silently apply to a report. Used by every reporting and serving command.
+func loadConfig(cmd *cobra.Command) (config.Config, error) {
+	cfg, err := loadConfigRaw(cmd)
+	if err != nil {
+		return config.Config{}, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return config.Config{}, err
+	}
+	return cfg, nil
+}
+
+// loadConfigLenient loads the merged config but only WARNS on an invalid one, returning it
+// anyway. The diagnostic and import commands (doctor, backfill) use it: they do not consume
+// the validated report settings and must keep working on a broken config so the user can
+// diagnose it and still import data. The config command loads raw and warns itself.
+func loadConfigLenient(cmd *cobra.Command) (config.Config, error) {
+	cfg, err := loadConfigRaw(cmd)
+	if err != nil {
+		return config.Config{}, err
+	}
+	if verr := cfg.Validate(); verr != nil {
+		cmd.PrintErrf("warning: %v (ignored for this command)\n", verr)
+	}
+	return cfg, nil
 }
 
 // configPath returns the config path in effect and whether it was set explicitly via

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -55,7 +55,7 @@ func runStatus(cmd *cobra.Command, since *string) error {
 	}
 	cmd.Printf("store: %s\n%d record(s)\n\n", dbPath, n)
 	if n == 0 {
-		return report.RenderEmptyStatusHint(cmd.OutOrStdout())
+		return emptyStatusHint(cmd)
 	}
 
 	start, err := parseSinceAt(*since, time.Now())

--- a/internal/cli/survival.go
+++ b/internal/cli/survival.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/assaio/assaio/internal/survival"
+)
+
+func newSurvivalCmd() *cobra.Command {
+	var since, repo string
+	c := &cobra.Command{
+		Use:   "survival",
+		Short: "Directional AI-code survival: how much of a repo's recent commits still live in HEAD, beside your AI usage",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runSurvival(cmd, since, repo)
+		},
+	}
+	c.Flags().StringVar(&since, "since", "90d", "window, e.g. 90d")
+	c.Flags().StringVar(&repo, "repo", ".", "path to the git repository to analyze")
+	addDBFlag(c)
+	return c
+}
+
+func runSurvival(cmd *cobra.Command, since, repo string) error {
+	start, err := parseSinceAt(since, time.Now())
+	if err != nil {
+		return err
+	}
+	root, err := survival.RepoRoot(cmd.Context(), repo)
+	if err != nil {
+		return err
+	}
+	aiLines, err := projectAILines(cmd, survival.Project(root), start)
+	if err != nil {
+		return err
+	}
+	res, err := survival.Analyze(cmd.Context(), root, start, aiLines)
+	if err != nil {
+		return err
+	}
+	return renderSurvival(cmd, &res, since)
+}
+
+// projectAILines sums the AI lines the store recorded for project since start.
+func projectAILines(cmd *cobra.Command, project string, start time.Time) (int64, error) {
+	st, err := openReportStore(cmd)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = st.Close() }()
+	rows, err := st.Usage(cmd.Context(), start)
+	if err != nil {
+		return 0, err
+	}
+	var lines int64
+	for i := range rows {
+		if rows[i].Project == project {
+			lines += rows[i].LinesAdded
+		}
+	}
+	return lines, nil
+}
+
+func renderSurvival(cmd *cobra.Command, res *survival.Result, since string) error {
+	rate := "—"
+	if res.SurvivalRate >= 0 {
+		rate = fmt.Sprintf("%.0f%%", res.SurvivalRate*100)
+	}
+	cmd.Printf("Survival · %s   window: %s\n", res.Project, windowLabel(since))
+	cmd.Printf("  %d commits in window · %d files blamed\n\n", res.Commits, res.Files)
+	cmd.Printf("  AI lines (assaio):   %d\n", res.AILines)
+	cmd.Printf("  Lines added (git):   %d\n", res.GitAdded)
+	cmd.Printf("  Surviving in HEAD:   %d  (%s)\n\n", res.Surviving, rate)
+	cmd.Println("  Directional: assaio counts AI lines but cannot tell which git lines were AI-written,")
+	cmd.Println("  so this is repo-wide survival of the window's commits shown beside your AI usage -- a")
+	cmd.Println("  correlation to read, not a per-line AI-survival number. Age-matched bug/quality impact")
+	cmd.Println("  and team-wide DORA signals are the server stage (see ROADMAP).")
+	return nil
+}

--- a/internal/dashboard/costbasis.go
+++ b/internal/dashboard/costbasis.go
@@ -13,6 +13,9 @@ func costBasis(inv report.Inventory, window string) string {
 	total := "—"
 	if inv.TotalCost != nil {
 		total = formatCompactUSD(*inv.TotalCost)
+		if inv.HasUnpriced {
+			total += "*"
+		}
 	}
 	perDay := "—"
 	if inv.TotalCost != nil && inv.Days > 0 {

--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -67,7 +67,7 @@ func Build(in analyze.Input, window string, anonymize bool, subpaths []store.Sub
 		Team:       team,
 		Inventory:  Inventory{Projects: inv.Projects, Sessions: len(in.Sessions), ActiveDays: inv.Days},
 		CostBasis:  costBasis(inv, window),
-		Caveats:    caveats(anonymize),
+		Caveats:    caveats(anonymize, inv.HasUnpriced),
 	}
 }
 
@@ -102,10 +102,13 @@ func anonymizeVerdicts(verdicts []analyze.Result) {
 // caveats returns the colophon's honesty notes: the locale's directional/coverage/quality
 // lines plus the shared cost-estimate disclosure, adding the pseudonymization note only
 // when anonymize is true.
-func caveats(anonymize bool) []string {
+func caveats(anonymize, hasUnpriced bool) []string {
 	// report.CostEstimateDisclosure is sourced from internal/report so the cost-basis
 	// wording is identical here and on the CLI cost tables -- one canonical string.
 	out := []string{en.DirectionalCaveat, en.LineCoverageCaveat, en.QualityCaveat, report.CostEstimateDisclosure}
+	if hasUnpriced {
+		out = append(out, en.UnpricedCaveat)
+	}
 	if anonymize {
 		out = append(out, en.AnonymizedCaveat)
 	}

--- a/internal/dashboard/drill.go
+++ b/internal/dashboard/drill.go
@@ -74,11 +74,28 @@ func buildDrill(in analyze.Input, subpaths []store.SubpathRow, anonymize bool) *
 
 	if anonymize {
 		name = report.Pseudonym("project", name)
+		subpaths = pseudonymizeSubpaths(subpaths)
 	}
 	return &ProjectDrill{
 		Name: name, Lines: scoped.Totals.Lines, Sessions: len(scoped.Sessions),
 		Verdicts: verdicts, Subpaths: subpaths,
 	}
+}
+
+// pseudonymizeSubpaths returns a copy of rows with each non-empty Subpath replaced by a
+// stable pseudonym, so an anonymized dashboard's drill table never leaks a real
+// repository path (e.g. "apps/mobile", or an internal product/client name) beside a
+// pseudonymized project. The empty (repository-root) subpath is left as-is: it carries no
+// name to leak and renders as the "(root)" row.
+func pseudonymizeSubpaths(rows []store.SubpathRow) []store.SubpathRow {
+	out := make([]store.SubpathRow, len(rows))
+	for i := range rows {
+		out[i] = rows[i]
+		if rows[i].Subpath != "" {
+			out[i].Subpath = report.Pseudonym("subpath", rows[i].Subpath)
+		}
+	}
+	return out
 }
 
 func filterUsageByProject(rows []store.UsageRow, project string) []store.UsageRow {

--- a/internal/dashboard/locale.go
+++ b/internal/dashboard/locale.go
@@ -39,6 +39,7 @@ type localeStrings struct {
 	TotalRow           string // subpath table's footer row label
 	CostBasisPrefix    string // footnote, before the computed cost-basis value
 	CostBasisSuffix    string // footnote's fixed tagline, after the value
+	UnpricedCaveat     string // colophon line, shown only when some cost was excluded as unpriced
 	DirectionalCaveat  string // colophon line: the directional/privacy-posture note
 	LineCoverageCaveat string // colophon line: which tools contribute AI-line counts
 	QualityCaveat      string // colophon line: quality signals need the server stage
@@ -72,6 +73,7 @@ var en = localeStrings{
 	TotalRow:           "Total",
 	CostBasisPrefix:    "Cost basis",
 	CostBasisSuffix:    "the denominator, not the grade.",
+	UnpricedCaveat:     "Cost figures marked * exclude usage on unpriced models -- a floor, not the full total.",
 	DirectionalCaveat:  "Directional assay -- aggregate and pseudonymized by default; per-person requires an explicit opt-in (team mode).",
 	LineCoverageCaveat: "AI-line signals: Claude Code and Codex today -- Gemini CLI and Cline contribute cost but not line counts (see ROADMAP).",
 	QualityCaveat:      "Quality signals (survival in main, bug impact) need git/issue correlation -- server stage.",

--- a/internal/dashboard/render_test.go
+++ b/internal/dashboard/render_test.go
@@ -76,6 +76,27 @@ func TestRenderHTMLGoldenRealNames(t *testing.T) {
 	renderAndCompareGolden(t, &d, "testdata/dashboard_real.golden.html")
 }
 
+// TestRenderHTMLAnonymizedHidesSubpaths guards the honesty rule that the shareable
+// (anonymized) dashboard must not leak a real repository subpath beside a pseudonymized
+// project -- the drill's subpath table was previously passed through verbatim, so a
+// distinctive path both de-anonymized the project and exposed internal names. The empty
+// root subpath carries no name and is exempt.
+func TestRenderHTMLAnonymizedHidesSubpaths(t *testing.T) {
+	var buf bytes.Buffer
+	if err := RenderHTML(&buf, Build(fixtureInput(), "last 30 days", true, fixtureSubpaths(), nil)); err != nil {
+		t.Fatal(err)
+	}
+	html := buf.String()
+	for _, row := range fixtureSubpaths() {
+		if row.Subpath != "" && strings.Contains(html, row.Subpath) {
+			t.Fatalf("anonymized dashboard leaks real subpath %q", row.Subpath)
+		}
+	}
+	if !strings.Contains(html, "subpath-") {
+		t.Fatal("anonymized dashboard must show a pseudonymized subpath label")
+	}
+}
+
 func renderAndCompareGolden(t *testing.T, d *Data, golden string) {
 	t.Helper()
 	var buf bytes.Buffer

--- a/internal/dashboard/team.go
+++ b/internal/dashboard/team.go
@@ -38,7 +38,7 @@ func buildTeam(usageRows []store.UsageRow, sessionRows []store.SessionRow, price
 		return nil
 	}
 
-	lines, cost, hasCost := memberTotals(usageRows, prices)
+	lines, cost, hasCost, unpriced := memberTotals(usageRows, prices)
 	sessions, members := memberSessionCounts(sessionRows)
 	for m := range lines {
 		members[m] = struct{}{}
@@ -58,7 +58,7 @@ func buildTeam(usageRows []store.UsageRow, sessionRows []store.SessionRow, price
 			Member:      memberLabel(m, anonymize),
 			Sessions:    sessions[m],
 			LinesAdded:  lines[m],
-			CostDisplay: costDisplay(cost[m], hasCost[m]),
+			CostDisplay: costDisplay(cost[m], hasCost[m], unpriced[m]),
 			Frac:        fraction(sessions[m], maxSessions),
 		})
 	}
@@ -78,19 +78,24 @@ func hasMemberData(rows []store.UsageRow) bool {
 }
 
 // memberTotals sums each member's AI lines and (when priced) cost across usageRows.
-func memberTotals(rows []store.UsageRow, prices pricing.Table) (lines map[string]int64, cost map[string]float64, hasCost map[string]bool) {
+// unpriced[m] marks a member whose cost excludes at least one unpriced-model row, so
+// costDisplay can flag their figure as a floor rather than the full spend.
+func memberTotals(rows []store.UsageRow, prices pricing.Table) (lines map[string]int64, cost map[string]float64, hasCost, unpriced map[string]bool) {
 	lines = make(map[string]int64)
 	cost = make(map[string]float64)
 	hasCost = make(map[string]bool)
+	unpriced = make(map[string]bool)
 	for i := range rows {
 		m := rows[i].Member
 		lines[m] += rows[i].LinesAdded
 		if c, ok := prices.CostTokens(rows[i].Model, rows[i].In, rows[i].Out, rows[i].CacheWrite, rows[i].CacheRead); ok {
 			cost[m] += c
 			hasCost[m] = true
+		} else {
+			unpriced[m] = true
 		}
 	}
-	return lines, cost, hasCost
+	return lines, cost, hasCost, unpriced
 }
 
 // memberSessionCounts counts sessions per member and returns the set of members seen.
@@ -134,12 +139,17 @@ func memberLabel(m string, anonymize bool) string {
 }
 
 // costDisplay renders a member's summed cost compactly, or "—" when none of their usage
-// was priced -- never a fabricated zero.
-func costDisplay(cost float64, hasCost bool) string {
+// was priced -- never a fabricated zero. A "*" marks a cost that excludes some unpriced
+// usage, so it reads as a floor rather than the member's full spend.
+func costDisplay(cost float64, hasCost, unpriced bool) string {
 	if !hasCost {
 		return "—"
 	}
-	return formatCompactUSD(cost)
+	s := formatCompactUSD(cost)
+	if unpriced {
+		s += "*"
+	}
+	return s
 }
 
 // fraction is v/max, 0 when max is 0 -- never a divide-by-zero.

--- a/internal/dashboard/testdata/dashboard.golden.html
+++ b/internal/dashboard/testdata/dashboard.golden.html
@@ -463,12 +463,12 @@ table.subpath tbody tr:hover td{background:var(--bg);}
   </header>
 
   <div class="panel-label">
-    <span><strong>Assay verdict</strong> · 5 reads</span>
+    <span><strong>Assay verdict</strong> · 12 reads</span>
     <span>2 projects · last 30 days</span>
   </div>
 
   
-  <section class="faceplate" aria-label="Assay verdict, 5 dimensions">
+  <section class="faceplate" aria-label="Assay verdict, 12 dimensions">
     
 <div class="cell">
   <span class="cell__label">01 · Adoption &amp; Usage Breadth</span>
@@ -483,7 +483,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">02 · Context Health</span>
+  <span class="cell__label">02 · Cache Hygiene</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--watch">WATCH</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">03 · Context Health</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     
@@ -495,7 +507,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">03 · Model Fit</span>
+  <span class="cell__label">04 · Coverage &amp; Confidence</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--good">SOLID</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">05 · Model Fit</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     <span class="prov">Prov.</span>
@@ -507,7 +531,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">04 · Rework &amp; Rejection</span>
+  <span class="cell__label">06 · Model Right-Sizing</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">07 · Reasoning Share</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--good">LEAN</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">08 · Rework &amp; Rejection</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">LOW</span>
     <span class="prov">Prov.</span>
@@ -519,7 +567,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">05 · Throughput</span>
+  <span class="cell__label">09 · Session Taxonomy</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">10 · Subscription Fit</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">SET PLAN</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">11 · Throughput</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">RAMPING</span>
     
@@ -527,6 +599,18 @@ table.subpath tbody tr:hover td{background:var(--bg);}
   <div class="cell__foot">
     <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
     <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">12 · Turn Efficiency</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
   </div>
 </div>
 
@@ -600,6 +684,46 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 <article class="entry">
   <div class="entry__gutter">
     <span class="entry__num">02</span>
+    <span class="entry__label">Cache Hygiene</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--watch">WATCH</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">High cache reuse means repeated context is served cheaply from cache instead of re-billed as fresh input. It is a cost signal, not a quality one -- a big one-shot task legitimately shows low reuse, and vendor cache lifetimes are invisible here.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">cache-read share</span>
+        <span class="stat__note">of billed input</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0</span>
+        <span class="stat__label">cache reads</span>
+        
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0</span>
+        <span class="stat__label">cache writes</span>
+        
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">High reuse is cheaper, not better work -- a large one-shot task legitimately shows low reuse.</p><p class="entry__caveat">Vendor cache lifetimes (TTLs) are invisible, so this is a day-grain approximation.</p>
+    <p class="entry__takeaway">Little input is served from cache this window -- expected for one-shot or exploratory work.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">03</span>
     <span class="entry__label">Context Health</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--watch">WATCH</span>
@@ -657,7 +781,67 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 
 <article class="entry">
   <div class="entry__gutter">
-    <span class="entry__num">03</span>
+    <span class="entry__num">04</span>
+    <span class="entry__label">Coverage &amp; Confidence</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--good">SOLID</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">Coverage is the honesty backbone -- it says how much of every other figure rests on complete data. Low activity coverage means line and edit signals cover only part of your usage; low priced coverage means some cost is excluded, never a real zero.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">100%</span>
+        <span class="stat__label">activity coverage</span>
+        <span class="stat__note">lines/edits captured</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">100%</span>
+        <span class="stat__label">priced coverage</span>
+        <span class="stat__note">cost known</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0%</span>
+        <span class="stat__label">cost-only tokens</span>
+        <span class="stat__note">no line signals</span>
+      </div>
+      
+    </div>
+    
+    
+    <div class="entry__viz">
+      
+      <ul class="projectbars">
+        
+        <li>
+          <span class="projectbars__name">claude-code</span>
+          <span class="projectbars__bar"><span style="width:100.0%"></span></span>
+          <span class="projectbars__value tnum">&gt;99%</span>
+        </li>
+        
+        <li>
+          <span class="projectbars__name">codex</span>
+          <span class="projectbars__bar"><span style="width:0.2%"></span></span>
+          <span class="projectbars__value tnum">&lt;1%</span>
+        </li>
+        
+      </ul>
+      
+    </div>
+    
+    <p class="entry__caveat">Cost-only tools (Gemini CLI, Cline, plugins) contribute tokens and cost but no line or edit signals -- see ROADMAP.</p><p class="entry__caveat">Per-record granularity (turn vs session) is not yet surfaced, so a mix isn&#39;t flagged here.</p>
+    <p class="entry__takeaway">Most usage carries full activity and price data -- the other figures rest on solid coverage.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">05</span>
     <span class="entry__label">Model Fit</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--watch">WATCH</span>
@@ -723,7 +907,65 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 
 <article class="entry">
   <div class="entry__gutter">
-    <span class="entry__num">04</span>
+    <span class="entry__num">06</span>
+    <span class="entry__label">Model Right-Sizing</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">—</span>
+      
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">A premium-model turn that emits only a handful of output tokens is often boilerplate or a quick answer a cheaper model handles as well. On a flat plan this is about speed and rate limits, not dollars. Task difficulty is invisible, so this is a prompt to look at a few, never a verdict.</p>
+    
+    
+    
+    <p class="entry__takeaway">No premium-model turns in this window.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">07</span>
+    <span class="entry__label">Reasoning Share</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--good">LEAN</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">Reasoning tokens are billed as output. A high share means much of the model&#39;s work is internal deliberation, which can be overkill on routine tasks. Only some tools report reasoning (Codex and Gemini CLI today), so the coverage figure says how much of your output this even covers.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">reasoning share</span>
+        <span class="stat__note">of reporting output</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0</span>
+        <span class="stat__label">reasoning tokens</span>
+        
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">&lt;1%</span>
+        <span class="stat__label">reporting coverage</span>
+        <span class="stat__note">output from tools that report it</span>
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">Only Codex and Gemini CLI report reasoning tokens; Claude Code doesn&#39;t, so this covers part of your output.</p><p class="entry__caveat">Reasoning is a subset of output (already billed there); this is a composition signal, not extra cost.</p>
+    <p class="entry__takeaway">Reasoning is a modest share of reported output -- the thinking budget looks proportionate.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">08</span>
     <span class="entry__label">Rework &amp; Rejection</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--good">LOW</span>
@@ -757,7 +999,101 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 
 <article class="entry">
   <div class="entry__gutter">
-    <span class="entry__num">05</span>
+    <span class="entry__num">09</span>
+    <span class="entry__label">Session Taxonomy</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">—</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">Conversational sessions are real work -- design, debugging, and planning rarely touch files -- so a high conversational share is not waste. This is a mix, not a scorecard: read it to understand how you use AI, not to push every session toward edits.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">conversational</span>
+        <span class="stat__note">no file edits</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">100%</span>
+        <span class="stat__label">light-edit</span>
+        <span class="stat__note">1-10 edits</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0%</span>
+        <span class="stat__label">heavy-edit</span>
+        <span class="stat__note">&gt;10 edits</span>
+      </div>
+      
+    </div>
+    
+    
+    <div class="entry__viz">
+      
+      <ul class="projectbars">
+        
+        <li>
+          <span class="projectbars__name">conversational</span>
+          <span class="projectbars__bar"><span style="width:0.0%"></span></span>
+          <span class="projectbars__value tnum">0 (0%)</span>
+        </li>
+        
+        <li>
+          <span class="projectbars__name">light-edit</span>
+          <span class="projectbars__bar"><span style="width:100.0%"></span></span>
+          <span class="projectbars__value tnum">2 (100%)</span>
+        </li>
+        
+        <li>
+          <span class="projectbars__name">heavy-edit</span>
+          <span class="projectbars__bar"><span style="width:0.0%"></span></span>
+          <span class="projectbars__value tnum">0 (0%)</span>
+        </li>
+        
+      </ul>
+      
+    </div>
+    
+    <p class="entry__caveat">Conversational sessions are real work (design, debugging, planning) -- not idle time.</p><p class="entry__caveat">A thrash bucket needs per-session rework, which isn&#39;t stored yet, so it isn&#39;t split out here.</p>
+    <p class="entry__takeaway">Too few sessions this window to characterize the mix.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">10</span>
+    <span class="entry__label">Subscription Fit</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">SET PLAN</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">This projects your window&#39;s API-equivalent cost to a month at your active-day pace, then compares it against the flat plan price you configured. A high multiple means the plan is a bargain at your volume; below 1x means API pay-as-you-go might be cheaper. The API figure is an estimate at public prices, not your actual bill.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">~$165/mo</span>
+        <span class="stat__label">API-equivalent</span>
+        <span class="stat__note">projected estimate</span>
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">The API-equivalent $ is an estimate at public pay-as-you-go prices, not your actual bill.</p>
+    <p class="entry__takeaway">Set config.pricing.monthly_subscription_cost to see whether your flat plan beats API pricing at this volume.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">11</span>
     <span class="entry__label">Throughput</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--good">RAMPING</span>
@@ -802,8 +1138,8 @@ table.subpath tbody tr:hover td{background:var(--bg);}
         
         <li>
           <span class="projectbars__name">project-39f19de764</span>
-          <span class="projectbars__bar"><span style="width:10.4%"></span></span>
-          <span class="projectbars__value tnum">1916 lines</span>
+          <span class="projectbars__bar"><span style="width:10.6%"></span></span>
+          <span class="projectbars__value tnum">1966 lines</span>
         </li>
         
       </ul>
@@ -812,6 +1148,46 @@ table.subpath tbody tr:hover td{background:var(--bg);}
     
     
     <p class="entry__takeaway">AI-line output is ramping up week over week.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">12</span>
+    <span class="entry__label">Turn Efficiency</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">—</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">These are prompting-efficiency signals, not quality. A session that lands an edit in a turn or two is efficient; a long session can be deliberate, careful work. Task size is invisible here, so read it directionally, never as a per-person score.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">one-shot rate</span>
+        <span class="stat__note">code sessions in &lt;=2 turns</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">6</span>
+        <span class="stat__label">median turns</span>
+        <span class="stat__note">per code session</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">12.8K</span>
+        <span class="stat__label">output/turn</span>
+        <span class="stat__note">median tokens</span>
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">Task size is invisible in logs, so a low one-shot rate can mean hard problems, not weak prompting -- directional only.</p>
+    <p class="entry__takeaway">Too few code-producing sessions this window to judge prompting efficiency.</p>
   </div>
 </article>
 
@@ -842,7 +1218,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">02 · Context Health</span>
+  <span class="cell__label">02 · Cache Hygiene</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--watch">WATCH</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">03 · Context Health</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     
@@ -854,7 +1242,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">03 · Model Fit</span>
+  <span class="cell__label">04 · Coverage &amp; Confidence</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--good">SOLID</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">05 · Model Fit</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">HEALTHY</span>
     
@@ -866,7 +1266,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">04 · Rework &amp; Rejection</span>
+  <span class="cell__label">06 · Model Right-Sizing</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">07 · Reasoning Share</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">08 · Rework &amp; Rejection</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">LOW</span>
     <span class="prov">Prov.</span>
@@ -878,7 +1302,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">05 · Throughput</span>
+  <span class="cell__label">09 · Session Taxonomy</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">10 · Subscription Fit</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">SET PLAN</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">11 · Throughput</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     
@@ -886,6 +1334,18 @@ table.subpath tbody tr:hover td{background:var(--bg);}
   <div class="cell__foot">
     <div class="gauge"><span class="gauge__fill" style="--fill:50.0%"></span></div>
     <span class="cell__ratio tnum">0.50</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">12 · Turn Efficiency</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
   </div>
 </div>
 
@@ -899,7 +1359,7 @@ table.subpath tbody tr:hover td{background:var(--bg);}
         </thead>
         <tbody>
           
-          <tr><td>apps/mobile</td><td class="tnum">12000</td><td class="tnum">1</td></tr>
+          <tr><td>subpath-30ff2c3799</td><td class="tnum">12000</td><td class="tnum">1</td></tr>
           
           <tr><td>. (root)</td><td class="tnum">6496</td><td class="tnum">1</td></tr>
           

--- a/internal/dashboard/testdata/dashboard_real.golden.html
+++ b/internal/dashboard/testdata/dashboard_real.golden.html
@@ -463,12 +463,12 @@ table.subpath tbody tr:hover td{background:var(--bg);}
   </header>
 
   <div class="panel-label">
-    <span><strong>Assay verdict</strong> · 5 reads</span>
+    <span><strong>Assay verdict</strong> · 12 reads</span>
     <span>2 projects · last 30 days</span>
   </div>
 
   
-  <section class="faceplate" aria-label="Assay verdict, 5 dimensions">
+  <section class="faceplate" aria-label="Assay verdict, 12 dimensions">
     
 <div class="cell">
   <span class="cell__label">01 · Adoption &amp; Usage Breadth</span>
@@ -483,7 +483,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">02 · Context Health</span>
+  <span class="cell__label">02 · Cache Hygiene</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--watch">WATCH</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">03 · Context Health</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     
@@ -495,7 +507,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">03 · Model Fit</span>
+  <span class="cell__label">04 · Coverage &amp; Confidence</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--good">SOLID</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">05 · Model Fit</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     <span class="prov">Prov.</span>
@@ -507,7 +531,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">04 · Rework &amp; Rejection</span>
+  <span class="cell__label">06 · Model Right-Sizing</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">07 · Reasoning Share</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--good">LEAN</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">08 · Rework &amp; Rejection</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">LOW</span>
     <span class="prov">Prov.</span>
@@ -519,7 +567,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">05 · Throughput</span>
+  <span class="cell__label">09 · Session Taxonomy</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">10 · Subscription Fit</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">SET PLAN</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">11 · Throughput</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">RAMPING</span>
     
@@ -527,6 +599,18 @@ table.subpath tbody tr:hover td{background:var(--bg);}
   <div class="cell__foot">
     <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
     <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">12 · Turn Efficiency</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
   </div>
 </div>
 
@@ -600,6 +684,46 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 <article class="entry">
   <div class="entry__gutter">
     <span class="entry__num">02</span>
+    <span class="entry__label">Cache Hygiene</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--watch">WATCH</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">High cache reuse means repeated context is served cheaply from cache instead of re-billed as fresh input. It is a cost signal, not a quality one -- a big one-shot task legitimately shows low reuse, and vendor cache lifetimes are invisible here.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">cache-read share</span>
+        <span class="stat__note">of billed input</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0</span>
+        <span class="stat__label">cache reads</span>
+        
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0</span>
+        <span class="stat__label">cache writes</span>
+        
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">High reuse is cheaper, not better work -- a large one-shot task legitimately shows low reuse.</p><p class="entry__caveat">Vendor cache lifetimes (TTLs) are invisible, so this is a day-grain approximation.</p>
+    <p class="entry__takeaway">Little input is served from cache this window -- expected for one-shot or exploratory work.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">03</span>
     <span class="entry__label">Context Health</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--watch">WATCH</span>
@@ -657,7 +781,67 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 
 <article class="entry">
   <div class="entry__gutter">
-    <span class="entry__num">03</span>
+    <span class="entry__num">04</span>
+    <span class="entry__label">Coverage &amp; Confidence</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--good">SOLID</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">Coverage is the honesty backbone -- it says how much of every other figure rests on complete data. Low activity coverage means line and edit signals cover only part of your usage; low priced coverage means some cost is excluded, never a real zero.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">100%</span>
+        <span class="stat__label">activity coverage</span>
+        <span class="stat__note">lines/edits captured</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">100%</span>
+        <span class="stat__label">priced coverage</span>
+        <span class="stat__note">cost known</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0%</span>
+        <span class="stat__label">cost-only tokens</span>
+        <span class="stat__note">no line signals</span>
+      </div>
+      
+    </div>
+    
+    
+    <div class="entry__viz">
+      
+      <ul class="projectbars">
+        
+        <li>
+          <span class="projectbars__name">claude-code</span>
+          <span class="projectbars__bar"><span style="width:100.0%"></span></span>
+          <span class="projectbars__value tnum">&gt;99%</span>
+        </li>
+        
+        <li>
+          <span class="projectbars__name">codex</span>
+          <span class="projectbars__bar"><span style="width:0.2%"></span></span>
+          <span class="projectbars__value tnum">&lt;1%</span>
+        </li>
+        
+      </ul>
+      
+    </div>
+    
+    <p class="entry__caveat">Cost-only tools (Gemini CLI, Cline, plugins) contribute tokens and cost but no line or edit signals -- see ROADMAP.</p><p class="entry__caveat">Per-record granularity (turn vs session) is not yet surfaced, so a mix isn&#39;t flagged here.</p>
+    <p class="entry__takeaway">Most usage carries full activity and price data -- the other figures rest on solid coverage.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">05</span>
     <span class="entry__label">Model Fit</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--watch">WATCH</span>
@@ -723,7 +907,65 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 
 <article class="entry">
   <div class="entry__gutter">
-    <span class="entry__num">04</span>
+    <span class="entry__num">06</span>
+    <span class="entry__label">Model Right-Sizing</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">—</span>
+      
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">A premium-model turn that emits only a handful of output tokens is often boilerplate or a quick answer a cheaper model handles as well. On a flat plan this is about speed and rate limits, not dollars. Task difficulty is invisible, so this is a prompt to look at a few, never a verdict.</p>
+    
+    
+    
+    <p class="entry__takeaway">No premium-model turns in this window.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">07</span>
+    <span class="entry__label">Reasoning Share</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--good">LEAN</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">Reasoning tokens are billed as output. A high share means much of the model&#39;s work is internal deliberation, which can be overkill on routine tasks. Only some tools report reasoning (Codex and Gemini CLI today), so the coverage figure says how much of your output this even covers.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">reasoning share</span>
+        <span class="stat__note">of reporting output</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0</span>
+        <span class="stat__label">reasoning tokens</span>
+        
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">&lt;1%</span>
+        <span class="stat__label">reporting coverage</span>
+        <span class="stat__note">output from tools that report it</span>
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">Only Codex and Gemini CLI report reasoning tokens; Claude Code doesn&#39;t, so this covers part of your output.</p><p class="entry__caveat">Reasoning is a subset of output (already billed there); this is a composition signal, not extra cost.</p>
+    <p class="entry__takeaway">Reasoning is a modest share of reported output -- the thinking budget looks proportionate.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">08</span>
     <span class="entry__label">Rework &amp; Rejection</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--good">LOW</span>
@@ -757,7 +999,101 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 
 <article class="entry">
   <div class="entry__gutter">
-    <span class="entry__num">05</span>
+    <span class="entry__num">09</span>
+    <span class="entry__label">Session Taxonomy</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">—</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">Conversational sessions are real work -- design, debugging, and planning rarely touch files -- so a high conversational share is not waste. This is a mix, not a scorecard: read it to understand how you use AI, not to push every session toward edits.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">conversational</span>
+        <span class="stat__note">no file edits</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">100%</span>
+        <span class="stat__label">light-edit</span>
+        <span class="stat__note">1-10 edits</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">0%</span>
+        <span class="stat__label">heavy-edit</span>
+        <span class="stat__note">&gt;10 edits</span>
+      </div>
+      
+    </div>
+    
+    
+    <div class="entry__viz">
+      
+      <ul class="projectbars">
+        
+        <li>
+          <span class="projectbars__name">conversational</span>
+          <span class="projectbars__bar"><span style="width:0.0%"></span></span>
+          <span class="projectbars__value tnum">0 (0%)</span>
+        </li>
+        
+        <li>
+          <span class="projectbars__name">light-edit</span>
+          <span class="projectbars__bar"><span style="width:100.0%"></span></span>
+          <span class="projectbars__value tnum">2 (100%)</span>
+        </li>
+        
+        <li>
+          <span class="projectbars__name">heavy-edit</span>
+          <span class="projectbars__bar"><span style="width:0.0%"></span></span>
+          <span class="projectbars__value tnum">0 (0%)</span>
+        </li>
+        
+      </ul>
+      
+    </div>
+    
+    <p class="entry__caveat">Conversational sessions are real work (design, debugging, planning) -- not idle time.</p><p class="entry__caveat">A thrash bucket needs per-session rework, which isn&#39;t stored yet, so it isn&#39;t split out here.</p>
+    <p class="entry__takeaway">Too few sessions this window to characterize the mix.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">10</span>
+    <span class="entry__label">Subscription Fit</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">SET PLAN</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">This projects your window&#39;s API-equivalent cost to a month at your active-day pace, then compares it against the flat plan price you configured. A high multiple means the plan is a bargain at your volume; below 1x means API pay-as-you-go might be cheaper. The API figure is an estimate at public prices, not your actual bill.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">~$165/mo</span>
+        <span class="stat__label">API-equivalent</span>
+        <span class="stat__note">projected estimate</span>
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">The API-equivalent $ is an estimate at public pay-as-you-go prices, not your actual bill.</p>
+    <p class="entry__takeaway">Set config.pricing.monthly_subscription_cost to see whether your flat plan beats API pricing at this volume.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">11</span>
     <span class="entry__label">Throughput</span>
     <div class="cell__read-row">
       <span class="entry__read entry__read--good">RAMPING</span>
@@ -802,8 +1138,8 @@ table.subpath tbody tr:hover td{background:var(--bg);}
         
         <li>
           <span class="projectbars__name">web</span>
-          <span class="projectbars__bar"><span style="width:10.4%"></span></span>
-          <span class="projectbars__value tnum">1916 lines</span>
+          <span class="projectbars__bar"><span style="width:10.6%"></span></span>
+          <span class="projectbars__value tnum">1966 lines</span>
         </li>
         
       </ul>
@@ -812,6 +1148,46 @@ table.subpath tbody tr:hover td{background:var(--bg);}
     
     
     <p class="entry__takeaway">AI-line output is ramping up week over week.</p>
+  </div>
+</article>
+
+<article class="entry">
+  <div class="entry__gutter">
+    <span class="entry__num">12</span>
+    <span class="entry__label">Turn Efficiency</span>
+    <div class="cell__read-row">
+      <span class="entry__read entry__read--neutral">—</span>
+      <span class="prov">Prov.</span>
+    </div>
+  </div>
+  <div>
+    <p class="entry__howto">These are prompting-efficiency signals, not quality. A session that lands an edit in a turn or two is efficient; a long session can be deliberate, careful work. Task size is invisible here, so read it directionally, never as a per-person score.</p>
+    
+    <div class="entry__stats">
+      
+      <div class="stat">
+        <span class="stat__value stat__value--accent">0%</span>
+        <span class="stat__label">one-shot rate</span>
+        <span class="stat__note">code sessions in &lt;=2 turns</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">6</span>
+        <span class="stat__label">median turns</span>
+        <span class="stat__note">per code session</span>
+      </div>
+      
+      <div class="stat">
+        <span class="stat__value">12.8K</span>
+        <span class="stat__label">output/turn</span>
+        <span class="stat__note">median tokens</span>
+      </div>
+      
+    </div>
+    
+    
+    <p class="entry__caveat">Task size is invisible in logs, so a low one-shot rate can mean hard problems, not weak prompting -- directional only.</p>
+    <p class="entry__takeaway">Too few code-producing sessions this window to judge prompting efficiency.</p>
   </div>
 </article>
 
@@ -842,7 +1218,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">02 · Context Health</span>
+  <span class="cell__label">02 · Cache Hygiene</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--watch">WATCH</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">03 · Context Health</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     
@@ -854,7 +1242,19 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">03 · Model Fit</span>
+  <span class="cell__label">04 · Coverage &amp; Confidence</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--good">SOLID</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">05 · Model Fit</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">HEALTHY</span>
     
@@ -866,7 +1266,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">04 · Rework &amp; Rejection</span>
+  <span class="cell__label">06 · Model Right-Sizing</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">07 · Reasoning Share</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">08 · Rework &amp; Rejection</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--good">LOW</span>
     <span class="prov">Prov.</span>
@@ -878,7 +1302,31 @@ table.subpath tbody tr:hover td{background:var(--bg);}
 </div>
 
 <div class="cell">
-  <span class="cell__label">05 · Throughput</span>
+  <span class="cell__label">09 · Session Taxonomy</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:100.0%"></span></div>
+    <span class="cell__ratio tnum">1.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">10 · Subscription Fit</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">SET PLAN</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">11 · Throughput</span>
   <div class="cell__read-row">
     <span class="cell__read cell__read--watch">WATCH</span>
     
@@ -886,6 +1334,18 @@ table.subpath tbody tr:hover td{background:var(--bg);}
   <div class="cell__foot">
     <div class="gauge"><span class="gauge__fill" style="--fill:50.0%"></span></div>
     <span class="cell__ratio tnum">0.50</span>
+  </div>
+</div>
+
+<div class="cell">
+  <span class="cell__label">12 · Turn Efficiency</span>
+  <div class="cell__read-row">
+    <span class="cell__read cell__read--neutral">—</span>
+    <span class="prov">Prov.</span>
+  </div>
+  <div class="cell__foot">
+    <div class="gauge"><span class="gauge__fill" style="--fill:0.0%"></span></div>
+    <span class="cell__ratio tnum">0.00</span>
   </div>
 </div>
 

--- a/internal/parser/cline/cline.go
+++ b/internal/parser/cline/cline.go
@@ -8,6 +8,7 @@ package cline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -55,16 +56,36 @@ type modelUsageEntry struct {
 // directory's basename, which Cline assigns once and never reuses for another directory,
 // so -- unlike a resumable session id -- it cannot collide across two different files.
 func ParseTask(uiMessages io.Reader, taskID string, meta taskMetadata) ([]usage.Record, int, error) {
-	var msgs []uiMessage
-	if err := json.NewDecoder(uiMessages).Decode(&msgs); err != nil {
+	models := sortedModelUsage(meta.ModelUsage)
+	dec := json.NewDecoder(uiMessages)
+	// Stream the array element-by-element rather than decoding it whole: ui_messages.json
+	// is a live file Cline rewrites and extends, so a read racing a write can see a
+	// truncated array. Streaming keeps every message decoded before the break instead of
+	// losing the whole task -- skip-and-count, per the parser contract.
+	tok, err := dec.Token()
+	if err != nil {
 		return nil, 0, err
 	}
-	models := sortedModelUsage(meta.ModelUsage)
+	if d, ok := tok.(json.Delim); !ok || d != '[' {
+		return nil, 0, fmt.Errorf("ui_messages.json is not a JSON array (got %v)", tok)
+	}
 
 	var out []usage.Record
 	var skipped int
 	index := 0
-	for _, m := range msgs {
+	for dec.More() {
+		var m uiMessage
+		if err := dec.Decode(&m); err != nil {
+			skipped++
+			// A type error (e.g. a float ts an int64 field rejects) consumed just this
+			// element, so keep reading; a syntax error or truncation leaves the decoder
+			// unusable, so stop and keep what was recovered before it.
+			var typeErr *json.UnmarshalTypeError
+			if !errors.As(err, &typeErr) {
+				break
+			}
+			continue
+		}
 		if m.Type != "say" || m.Say != "api_req_started" || m.Text == "" {
 			continue
 		}
@@ -133,7 +154,7 @@ func readTaskMetadata(taskDir string) (taskMetadata, error) {
 func sortedModelUsage(entries []modelUsageEntry) []modelUsageEntry {
 	sorted := make([]modelUsageEntry, len(entries))
 	copy(sorted, entries)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].TS < sorted[j].TS })
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].TS < sorted[j].TS })
 	return sorted
 }
 

--- a/internal/parser/cline/cline_test.go
+++ b/internal/parser/cline/cline_test.go
@@ -171,6 +171,56 @@ func TestParseTaskInvalidTextIsSkippedNotError(t *testing.T) {
 	}
 }
 
+// TestParseTaskTruncatedArrayKeepsRecordsBeforeTheBreak covers the skip-and-count fix for
+// a ui_messages.json truncated mid-write (Cline rewrites the file live, so a read can race
+// a write): every message decoded before the truncation is kept, and the broken tail is
+// counted rather than aborting the whole task.
+func TestParseTaskTruncatedArrayKeepsRecordsBeforeTheBreak(t *testing.T) {
+	const log = `[
+{"type":"say","say":"api_req_started","text":"{\"tokensIn\":10,\"tokensOut\":5}","ts":1751360400000},
+{"type":"say","say":"api_req_started","text":"{\"tokensIn\":20`
+	recs, skipped, err := ParseTask(strings.NewReader(log), "t4", taskMetadata{})
+	if err != nil {
+		t.Fatalf("a truncated array must not abort the whole task: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d records want 1 (the message before the truncation is kept)", len(recs))
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d want 1 (the truncated tail is counted)", skipped)
+	}
+}
+
+// TestParseTaskRecoversAfterRecoverableElementError covers the skip-and-count fix for a
+// single malformed element mid-array (a float ts the int64 field rejects): the element is
+// skipped and counted, but every valid record after it is still parsed -- only a syntax
+// error or truncation stops the stream.
+func TestParseTaskRecoversAfterRecoverableElementError(t *testing.T) {
+	const log = `[
+{"type":"say","say":"api_req_started","text":"{\"tokensIn\":10,\"tokensOut\":5}","ts":1751360400000},
+{"type":"say","say":"api_req_started","text":"{\"tokensIn\":20,\"tokensOut\":7}","ts":1.7513604e12},
+{"type":"say","say":"api_req_started","text":"{\"tokensIn\":30,\"tokensOut\":9}","ts":1751360400002}]`
+	recs, skipped, err := ParseTask(strings.NewReader(log), "t5", taskMetadata{})
+	if err != nil {
+		t.Fatalf("a recoverable element error must not abort the parse: %v", err)
+	}
+	if skipped != 1 {
+		t.Fatalf("skipped = %d want 1 (the float-ts element)", skipped)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records want 2 (the record after the bad element must survive)", len(recs))
+	}
+}
+
+// TestParseTaskRejectsNonArray covers the guard the streaming rewrite must keep: a
+// ui_messages.json that is not a JSON array (corrupt-to-an-object, wrong file) errors rather
+// than being counted as a clean, empty parse.
+func TestParseTaskRejectsNonArray(t *testing.T) {
+	if _, _, err := ParseTask(strings.NewReader(`{"foo":"bar"}`), "t6", taskMetadata{}); err == nil {
+		t.Fatal("a non-array ui_messages.json must be an error, not a silent empty parse")
+	}
+}
+
 func TestParseDirReadsBothFiles(t *testing.T) {
 	dir := t.TempDir()
 	taskDir := filepath.Join(dir, "task9")

--- a/internal/parser/codex/codex.go
+++ b/internal/parser/codex/codex.go
@@ -144,7 +144,13 @@ func (st *parseState) applySessionMeta(payload json.RawMessage) {
 		st.skipped++
 		return
 	}
-	st.session, st.ts = m.ID, m.Timestamp
+	st.session = m.ID
+	// Parse already advanced st.ts from this line's envelope timestamp; only let the
+	// payload override it when the payload actually carries one, so a session_meta whose
+	// payload omits the timestamp does not reset st.ts to the zero time.
+	if !m.Timestamp.IsZero() {
+		st.ts = m.Timestamp
+	}
 	if st.model == "" {
 		st.model = m.Model
 	}

--- a/internal/parser/codex/codex_test.go
+++ b/internal/parser/codex/codex_test.go
@@ -209,6 +209,27 @@ func TestPerLineTimestampFallsBackToLastKnownWhenLineLacksOne(t *testing.T) {
 	}
 }
 
+// TestSessionMetaEnvelopeTimestampSurvivesEmptyPayloadTimestamp guards the applySessionMeta
+// fix: when session_meta carries an envelope timestamp but its payload omits one, a later
+// line that also lacks its own timestamp must inherit the envelope's timestamp, not be
+// stamped with the zero time (the old code overwrote st.ts with the empty payload value).
+func TestSessionMetaEnvelopeTimestampSurvivesEmptyPayloadTimestamp(t *testing.T) {
+	const rollout = `{"type":"session_meta","timestamp":"2026-07-01T09:00:00Z","payload":{"id":"c12","cwd":"/home/dev/app12"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":50,"reasoning_output_tokens":0,"total_tokens":150}}}}
+`
+	recs, _, err := Parse(strings.NewReader(rollout))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("got %d records, want 1: %+v", len(recs), recs)
+	}
+	want := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	if !recs[0].Timestamp.Equal(want) {
+		t.Fatalf("recs[0].Timestamp = %v, want %v (envelope ts must survive an empty payload ts)", recs[0].Timestamp, want)
+	}
+}
+
 // TestDedupeKeyScopedToFileAcrossResumedSession covers the collision this parser used to
 // have: two different files (e.g. an original and a resumed-session rollout) that reuse
 // the same session id must not produce the same DedupeKey, or the second file's records

--- a/internal/parser/gemini/gemini.go
+++ b/internal/parser/gemini/gemini.go
@@ -44,7 +44,7 @@ func Parse(r io.Reader) ([]usage.Record, int, error) {
 	var out []usage.Record
 	var skipped int
 	index := 0
-	var fileFP string
+	var fileFP, sessionID string
 	for sc.Scan() {
 		raw := sc.Bytes()
 		if len(raw) == 0 {
@@ -58,19 +58,26 @@ func Parse(r io.Reader) ([]usage.Record, int, error) {
 			skipped++
 			continue
 		}
+		// The session id rides the file's header line and is not repeated on message
+		// lines, so carry the last-seen value forward (this also accepts an older per-line
+		// shape). Header and control records ($set/$rewindTo) carry no tokens and fall
+		// through the zero-token skip below.
+		if m.SessionID != "" {
+			sessionID = m.SessionID
+		}
 		if m.Tokens.Total == 0 && m.Tokens.Input == 0 && m.Tokens.Output == 0 {
 			continue
 		}
 		out = append(out, usage.Record{
 			Tool:            tool,
-			SessionID:       m.SessionID,
+			SessionID:       sessionID,
 			Timestamp:       m.Timestamp,
 			Model:           m.Model,
 			InputTokens:     parser.NonNeg(m.Tokens.Input - m.Tokens.Cached),
 			CacheReadTokens: parser.NonNeg(m.Tokens.Cached),
 			OutputTokens:    parser.NonNeg(m.Tokens.Output + m.Tokens.Tool + m.Tokens.Thoughts),
 			ReasoningTokens: parser.NonNeg(m.Tokens.Thoughts),
-			DedupeKey:       fmt.Sprintf("%s:%s:%d", fileFP, m.SessionID, index),
+			DedupeKey:       fmt.Sprintf("%s:%s:%d", fileFP, sessionID, index),
 			Granularity:     "turn",
 		})
 		index++

--- a/internal/parser/gemini/gemini_test.go
+++ b/internal/parser/gemini/gemini_test.go
@@ -234,3 +234,34 @@ func TestThinkingTokensContributeToCost(t *testing.T) {
 		t.Fatalf("Cost = %.10f, want > %.10f (old formula undercounted by ignoring thinking tokens)", got, oldCost)
 	}
 }
+
+// TestHeaderSessionIDCarriesForwardToMessages covers the real Gemini recording shape: the
+// session id rides the file's header line only, message lines omit it, and $set/$rewindTo
+// control records carry no tokens. Every emitted record must inherit the header's session
+// id, and the control records must be skipped without being counted as parse failures.
+func TestHeaderSessionIDCarriesForwardToMessages(t *testing.T) {
+	const log = `{"sessionId":"hdr-1","projectHash":"abc","startTime":"2026-07-01T10:00:00Z","kind":"main"}
+{"$set":{"summary":"a summary update"}}
+{"id":"m1","type":"gemini","timestamp":"2026-07-01T10:00:05Z","model":"gemini-2.5-pro","tokens":{"input":100,"output":50,"cached":0,"thoughts":0,"tool":0,"total":150}}
+{"$rewindTo":"m0"}
+{"id":"m2","type":"gemini","timestamp":"2026-07-01T10:00:10Z","model":"gemini-2.5-flash","tokens":{"input":200,"output":80,"cached":0,"thoughts":0,"tool":0,"total":280}}
+`
+	recs, skipped, err := Parse(strings.NewReader(log))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skipped != 0 {
+		t.Fatalf("skipped = %d, want 0 (header and control records are valid JSON, just token-less)", skipped)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d records, want 2 (only the two token-bearing message lines)", len(recs))
+	}
+	for i, rec := range recs {
+		if rec.SessionID != "hdr-1" {
+			t.Fatalf("recs[%d].SessionID = %q, want the header session id 'hdr-1'", i, rec.SessionID)
+		}
+		if !strings.Contains(rec.DedupeKey, ":hdr-1:") {
+			t.Fatalf("recs[%d].DedupeKey = %q, want the header session id in the key", i, rec.DedupeKey)
+		}
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -60,29 +60,37 @@ func GeminiRoot(home string) string {
 }
 
 // ClineRoots returns the root directories that may contain Cline task data under home:
-// the VS Code extension's global storage, and the Cline CLI data directory. Each root's
-// tasks live under a "tasks" subdirectory.
+// the Cline extension's global storage in each supported VS Code-family editor, and the
+// Cline CLI data directory. Each root's tasks live under a "tasks" subdirectory.
 func ClineRoots(home string) []string {
 	return clineRootsFor(runtime.GOOS, home, os.Getenv("APPDATA"))
 }
 
-// clineRootsFor is the pure, OS-parameterized implementation behind ClineRoots.
+// clineEditorDirs are the VS Code-family user-data directory names that can host the Cline
+// extension's globalStorage: stable VS Code, Insiders, VSCodium, and Cursor. The same
+// publisher id lives under each, so Cline data is found wherever the user runs it.
+var clineEditorDirs = []string{"Code", "Code - Insiders", "VSCodium", "Cursor"}
+
+// clineRootsFor is the pure, OS-parameterized implementation behind ClineRoots: one
+// globalStorage root per editor in clineEditorDirs order, then the Cline CLI data
+// directory. Non-existent roots are skipped harmlessly at discovery time.
 func clineRootsFor(goos, home, appdata string) []string {
 	const extensionID = "saoudrizwan.claude-dev"
-	var vscodeGlobalStorage string
+	var userData string
 	switch goos {
 	case "darwin":
-		vscodeGlobalStorage = filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage")
+		userData = filepath.Join(home, "Library", "Application Support")
 	case "windows":
 		if appdata == "" {
 			appdata = filepath.Join(home, "AppData", "Roaming")
 		}
-		vscodeGlobalStorage = filepath.Join(appdata, "Code", "User", "globalStorage")
+		userData = appdata
 	default:
-		vscodeGlobalStorage = filepath.Join(home, ".config", "Code", "User", "globalStorage")
+		userData = filepath.Join(home, ".config")
 	}
-	return []string{
-		filepath.Join(vscodeGlobalStorage, extensionID),
-		filepath.Join(home, ".cline", "data"),
+	roots := make([]string, 0, len(clineEditorDirs)+1)
+	for _, editor := range clineEditorDirs {
+		roots = append(roots, filepath.Join(userData, editor, "User", "globalStorage", extensionID))
 	}
+	return append(roots, filepath.Join(home, ".cline", "data"))
 }

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -181,14 +181,14 @@ func TestRoots(t *testing.T) {
 func TestClineRoots(t *testing.T) {
 	home := "/home/dev"
 	roots := ClineRoots(home)
-	if len(roots) != 2 {
-		t.Fatalf("ClineRoots = %v, want 2 entries", roots)
+	if len(roots) != len(clineEditorDirs)+1 {
+		t.Fatalf("ClineRoots = %v, want %d entries", roots, len(clineEditorDirs)+1)
 	}
-	if roots[1] != filepath.Join(home, ".cline", "data") {
-		t.Fatalf("ClineRoots[1] = %q", roots[1])
+	if roots[len(roots)-1] != filepath.Join(home, ".cline", "data") {
+		t.Fatalf("ClineRoots last = %q, want the Cline CLI data dir", roots[len(roots)-1])
 	}
 	if filepath.Base(roots[0]) != "saoudrizwan.claude-dev" {
-		t.Fatalf("ClineRoots[0] = %q, want to end in extension id", roots[0])
+		t.Fatalf("ClineRoots[0] = %q, want to end in the extension id", roots[0])
 	}
 }
 
@@ -225,14 +225,23 @@ func TestClineRootsFor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			roots := clineRootsFor(tt.goos, home, tt.appdata)
-			if len(roots) != 2 {
-				t.Fatalf("clineRootsFor(%q) = %v, want 2 entries", tt.goos, roots)
+			if len(roots) != len(clineEditorDirs)+1 {
+				t.Fatalf("clineRootsFor(%q) = %v, want %d entries", tt.goos, roots, len(clineEditorDirs)+1)
 			}
 			if roots[0] != tt.want {
 				t.Fatalf("clineRootsFor(%q)[0] = %q, want %q", tt.goos, roots[0], tt.want)
 			}
-			if roots[1] != filepath.Join(home, ".cline", "data") {
-				t.Fatalf("clineRootsFor(%q)[1] = %q", tt.goos, roots[1])
+			if roots[len(roots)-1] != filepath.Join(home, ".cline", "data") {
+				t.Fatalf("clineRootsFor(%q) last = %q, want the Cline CLI data dir", tt.goos, roots[len(roots)-1])
+			}
+			for i, editor := range clineEditorDirs {
+				if filepath.Base(roots[i]) != "saoudrizwan.claude-dev" {
+					t.Fatalf("clineRootsFor(%q)[%d] = %q, want the extension id", tt.goos, i, roots[i])
+				}
+				// roots[i] = <userData>/<editor>/User/globalStorage/<extId>
+				if got := filepath.Base(filepath.Dir(filepath.Dir(filepath.Dir(roots[i])))); got != editor {
+					t.Fatalf("clineRootsFor(%q)[%d] editor segment = %q, want %q", tt.goos, i, got, editor)
+				}
 			}
 		})
 	}

--- a/internal/plugin/exec.go
+++ b/internal/plugin/exec.go
@@ -66,7 +66,7 @@ func run(ctx context.Context, cfg Config, collectViolations bool) ([]usage.Recor
 	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 
-	stdout := &cappedBuffer{cap: maxStdout}
+	stdout := &cappedBuffer{cap: maxStdout, cancel: cancel}
 	stderr := newPrefixWriter(os.Stderr, "[plugin/"+cfg.Name+"] ")
 	//nolint:gosec // the command is the user's own opt-in config entry, resolved via LookPath
 	cmd := exec.CommandContext(ctx, cfg.Command, "scan")
@@ -78,11 +78,13 @@ func run(ctx context.Context, cfg Config, collectViolations bool) ([]usage.Recor
 	runErr := cmd.Run()
 	stderr.Flush()
 
-	if ctx.Err() != nil {
-		return nil, nil, Stats{}, fmt.Errorf("plugin %s: timed out after %s", cfg.Name, cfg.Timeout)
-	}
+	// Check the cap breach before ctx.Err(): an overflow cancels the context itself, so
+	// testing ctx.Err() first would misreport a stdout flood as a timeout.
 	if stdout.exceeded {
 		return nil, nil, Stats{}, fmt.Errorf("plugin %s: stdout exceeded %d bytes", cfg.Name, maxStdout)
+	}
+	if ctx.Err() != nil {
+		return nil, nil, Stats{}, fmt.Errorf("plugin %s: timed out after %s", cfg.Name, cfg.Timeout)
 	}
 	if runErr != nil {
 		return nil, nil, Stats{}, fmt.Errorf("plugin %s: %w", cfg.Name, runErr)

--- a/internal/plugin/record.go
+++ b/internal/plugin/record.go
@@ -9,6 +9,12 @@ import (
 	"github.com/assaio/assaio/internal/usage"
 )
 
+// maxWireStringLen bounds any single string field a plugin emits: these are identities
+// and labels, not free text. With the stdout line cap it stops a plugin from smuggling a
+// multi-megabyte field into the store (the metric-result boundary caps strings the same
+// way, see metric_result.go).
+const maxWireStringLen = 512
+
 // wireRecord is the JSONL record shape a plugin emits, snake_case per the protocol spec
 // in docs/extending.md.
 type wireRecord struct {
@@ -37,6 +43,11 @@ func (w *wireRecord) toRecord(pluginName string) (usage.Record, error) {
 	}
 	if w.DedupeKey == "" {
 		return usage.Record{}, errors.New("empty dedupe_key")
+	}
+	for _, s := range []string{w.SessionID, w.Model, w.DedupeKey, w.Project, w.GitBranch, w.Entrypoint} {
+		if len(s) > maxWireStringLen {
+			return usage.Record{}, fmt.Errorf("string field exceeds %d bytes", maxWireStringLen)
+		}
 	}
 	if w.Granularity != "turn" && w.Granularity != "session" {
 		return usage.Record{}, fmt.Errorf("invalid granularity %q (want turn|session)", w.Granularity)

--- a/internal/plugin/record_test.go
+++ b/internal/plugin/record_test.go
@@ -1,6 +1,9 @@
 package plugin
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestParseRecordLine(t *testing.T) {
 	tests := []struct {
@@ -25,6 +28,17 @@ func TestParseRecordLine(t *testing.T) {
 				t.Fatalf("parseRecordLine() err = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// TestParseRecordLineRejectsOversizedStringField guards the boundary cap: a plugin cannot
+// smuggle a multi-kilobyte string field (here Model) past the record boundary into the
+// store, matching the metric-result boundary's own length caps.
+func TestParseRecordLineRejectsOversizedStringField(t *testing.T) {
+	big := strings.Repeat("x", maxWireStringLen+1)
+	line := `{"session_id":"s1","timestamp":"2026-07-01T10:00:00Z","model":"` + big + `","dedupe_key":"s1:0","granularity":"turn"}`
+	if _, err := parseRecordLine([]byte(line), "demo"); err == nil {
+		t.Fatal("want error for an oversized string field, got nil")
 	}
 }
 

--- a/internal/plugin/stream.go
+++ b/internal/plugin/stream.go
@@ -2,10 +2,16 @@ package plugin
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 )
+
+// maxStderrLine bounds a plugin's un-flushed stderr: a newline-free flood is force-emitted
+// and reset once it passes this, so a misbehaving subprocess writing endless bytes with no
+// newline cannot grow the buffer without bound (stdout has its own cappedBuffer cap).
+const maxStderrLine = 64 * 1024
 
 // maxStdout caps a plugin's stdout; a plugin that exceeds it is aborted with a clear
 // error rather than let assaio buffer unbounded memory for a misbehaving subprocess.
@@ -14,17 +20,23 @@ const maxStdout = 64 * 1024 * 1024
 // errStdoutCapped aborts the exec copy loop once a plugin exceeds maxStdout.
 var errStdoutCapped = errors.New("plugin stdout cap exceeded")
 
-// cappedBuffer buffers a plugin's stdout up to cap bytes, then rejects further writes
-// so the subprocess is cut off instead of filling memory.
+// cappedBuffer buffers a plugin's stdout up to cap bytes, then rejects further writes so
+// the subprocess is cut off instead of filling memory. On the first overflow it also
+// cancels the run's context, so the child is killed immediately rather than blocking on a
+// full pipe until the timeout elapses (which would misreport the cap breach as a timeout).
 type cappedBuffer struct {
 	buf      bytes.Buffer
 	cap      int
 	exceeded bool
+	cancel   context.CancelFunc
 }
 
 func (b *cappedBuffer) Write(p []byte) (int, error) {
 	if b.buf.Len()+len(p) > b.cap {
 		b.exceeded = true
+		if b.cancel != nil {
+			b.cancel()
+		}
 		return 0, errStdoutCapped
 	}
 	return b.buf.Write(p)
@@ -47,7 +59,13 @@ func (pw *prefixWriter) Write(p []byte) (int, error) {
 	for {
 		line, err := pw.partial.ReadString('\n')
 		if err != nil {
+			// No newline yet: re-buffer the remainder, but force-flush and reset once it
+			// passes maxStderrLine so an endless newline-free stream can't grow unbounded.
 			pw.partial.WriteString(line)
+			if pw.partial.Len() > maxStderrLine {
+				_, _ = fmt.Fprintf(pw.w, "%s%s\n", pw.prefix, pw.partial.String())
+				pw.partial.Reset()
+			}
 			break
 		}
 		_, _ = fmt.Fprintf(pw.w, "%s%s", pw.prefix, line)

--- a/internal/plugin/stream_test.go
+++ b/internal/plugin/stream_test.go
@@ -37,6 +37,24 @@ func TestPrefixWriterPrefixesEveryLine(t *testing.T) {
 	}
 }
 
+// TestPrefixWriterBoundsNewlineFreeFlood guards the stderr cap: a plugin writing an
+// endless newline-free stream must not grow prefixWriter.partial without bound -- once it
+// passes maxStderrLine it is force-flushed and the buffer reset.
+func TestPrefixWriterBoundsNewlineFreeFlood(t *testing.T) {
+	var out strings.Builder
+	pw := newPrefixWriter(&out, "[p] ")
+	big := strings.Repeat("A", maxStderrLine+1024)
+	if _, err := pw.Write([]byte(big)); err != nil {
+		t.Fatal(err)
+	}
+	if pw.partial.Len() > maxStderrLine {
+		t.Fatalf("partial = %d bytes, want <= %d (flushed on overflow)", pw.partial.Len(), maxStderrLine)
+	}
+	if out.Len() == 0 {
+		t.Fatal("flooded stderr must be force-flushed to the writer, not retained silently")
+	}
+}
+
 func TestScanOutputStdoutWithinCapParses(t *testing.T) {
 	out := []byte(`{"assaio_plugin":1,"tool":"demo"}` + "\n" +
 		`{"session_id":"s1","timestamp":"2026-07-01T10:00:00Z","model":"m","dedupe_key":"s1:0","granularity":"turn"}` + "\n")

--- a/internal/report/effectiveness.go
+++ b/internal/report/effectiveness.go
@@ -23,7 +23,8 @@ type EffRow struct {
 	ToolCalls int64 `json:"tool_calls"`
 	// Rejected is tool-use proposals the human declined: a friction signal.
 	Rejected int64 `json:"rejected"`
-	// TokensTotal sums input, output, cache-read, cache-write, and reasoning tokens.
+	// TokensTotal sums input, output, cache-read, and cache-write tokens. Reasoning
+	// tokens are a subset of output (usage.Record) and are never added again here.
 	TokensTotal int64 `json:"tokens_total"`
 	// Cost is USD cost summed from priced usage only; nil when nothing in the group priced.
 	Cost *float64 `json:"cost"`
@@ -82,7 +83,7 @@ func accumulateEff(g *EffRow, u *store.UsageRow, t pricing.Table) {
 	g.Edits += u.Edits
 	g.ToolCalls += u.ToolCalls
 	g.Rejected += u.Rejected
-	g.TokensTotal += u.In + u.Out + u.CacheRead + u.CacheWrite + u.Reasoning
+	g.TokensTotal += u.In + u.Out + u.CacheRead + u.CacheWrite
 
 	cost, ok := t.CostTokens(u.Model, u.In, u.Out, u.CacheWrite, u.CacheRead)
 	if !ok {

--- a/internal/report/movers.go
+++ b/internal/report/movers.go
@@ -59,7 +59,15 @@ func Movers(recent, prior []EffRow) []MoverRow {
 		m.DeltaLines = m.LinesNow - m.LinesPrior
 		out = append(out, *m)
 	}
-	sort.Slice(out, func(i, j int) bool { return absFloat(out[i].DeltaCost) > absFloat(out[j].DeltaCost) })
+	// Stable + name tiebreak so tied cost deltas (common when groups are all unpriced,
+	// making every delta 0) keep a deterministic, diffable order across runs.
+	sort.SliceStable(out, func(i, j int) bool {
+		di, dj := absFloat(out[i].DeltaCost), absFloat(out[j].DeltaCost)
+		if di != dj {
+			return di > dj
+		}
+		return out[i].Group < out[j].Group
+	})
 	return out
 }
 

--- a/internal/server/dashboard.go
+++ b/internal/server/dashboard.go
@@ -43,7 +43,12 @@ func BuildDashboard(ctx context.Context, st *store.Store) (dashboard.Data, error
 	if err != nil {
 		return dashboard.Data{}, err
 	}
+	turns, err := st.TurnSizing(ctx, since, analyze.RightSizeSmallOutput)
+	if err != nil {
+		return dashboard.Data{}, err
+	}
 	in := analyze.BuildInput(usageRows, sessionRows, table, time.Now(), dashboardRecentWindow, analyze.Delegation{})
+	in.TurnSizing = turns
 	const anonymize = true
 	// Exec metric plugins are deliberately nil here: GET / is unauthenticated and
 	// rebuilds per request, and spawning config-declared subprocesses per request would

--- a/internal/server/validate.go
+++ b/internal/server/validate.go
@@ -15,6 +15,11 @@ import (
 // distort the shared dashboard's SUM() aggregates.
 const maxFieldValue = 1_000_000_000
 
+// maxStringField bounds any single string field on a pushed record: these are identities
+// and labels, not free text. It blocks a client from smuggling a multi-megabyte model or
+// dedupe_key into the shared store and the unauthenticated dashboard it feeds.
+const maxStringField = 512
+
 // tsFloor is the earliest plausible record timestamp; anything before it (including the
 // zero value, year 1) is garbage. No AI-coding tool predates it.
 var tsFloor = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -52,6 +57,19 @@ func validateRecord(r *usage.Record) error {
 }
 
 func validateRecordAt(r *usage.Record, now time.Time) error {
+	// Only an empty dedupe_key is fatal: it is the ON CONFLICT(tool, dedupe_key) key, so a
+	// blank one collapses rows. session_id can legitimately be empty (the Claude parser does
+	// not guarantee it), and rejecting the whole push over it would break a client's entire
+	// sync on one stale row. Member is not checked here -- it is overwritten server-side and
+	// bounded by ValidateMember.
+	if r.DedupeKey == "" {
+		return errors.New("empty dedupe_key")
+	}
+	for _, s := range []string{r.Tool, r.SessionID, r.Model, r.DedupeKey, r.Project, r.Subpath, r.GitBranch, r.Entrypoint} {
+		if len(s) > maxStringField {
+			return fmt.Errorf("string field exceeds %d bytes", maxStringField)
+		}
+	}
 	if !knownTools[r.Tool] && !pluginToolPattern.MatchString(r.Tool) {
 		return fmt.Errorf("unknown tool %q", r.Tool)
 	}

--- a/internal/server/validate_test.go
+++ b/internal/server/validate_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -118,5 +119,41 @@ func TestValidateRecordAcceptsBoundaryMagnitude(t *testing.T) {
 	r.InputTokens = maxFieldValue
 	if err := validateRecord(&r); err != nil {
 		t.Fatalf("boundary value maxFieldValue should be accepted: %v", err)
+	}
+}
+
+// TestValidateRecordRejectsEmptyDedupeKey guards the honesty rule: an empty dedupe_key
+// collapses every such row into one under ON CONFLICT(tool, dedupe_key), silently
+// undercounting a member. An empty session_id is tolerated -- the Claude parser doesn't
+// guarantee it, and rejecting the whole push over one stale row would break a client's sync.
+func TestValidateRecordRejectsEmptyDedupeKey(t *testing.T) {
+	r := newValidRecord()
+	r.DedupeKey = ""
+	if err := validateRecord(&r); err == nil {
+		t.Fatal("empty dedupe_key: want error, got nil")
+	}
+
+	r = newValidRecord()
+	r.SessionID = ""
+	if err := validateRecord(&r); err != nil {
+		t.Fatalf("empty session_id should be tolerated, got %v", err)
+	}
+}
+
+// TestValidateRecordRejectsOversizedStringField guards the boundary cap: a token-holding
+// client cannot push a multi-megabyte string field into the shared store and the
+// unauthenticated dashboard it feeds -- including Tool, whose "plugin:<name>" regex is
+// otherwise length-unbounded.
+func TestValidateRecordRejectsOversizedStringField(t *testing.T) {
+	r := newValidRecord()
+	r.Model = strings.Repeat("x", maxStringField+1)
+	if err := validateRecord(&r); err == nil {
+		t.Fatal("want error for an oversized Model field, got nil")
+	}
+
+	r = newValidRecord()
+	r.Tool = "plugin:" + strings.Repeat("a", maxStringField)
+	if err := validateRecord(&r); err == nil {
+		t.Fatal("want error for an oversized Tool field, got nil")
 	}
 }

--- a/internal/store/schema.go
+++ b/internal/store/schema.go
@@ -41,10 +41,21 @@ func migrate(ctx context.Context, db *sql.DB) error {
 		if err != nil {
 			return err
 		}
-		if _, err := db.ExecContext(ctx, string(body)); err != nil {
+		// Apply the body and record it in one transaction, so a crash between them can
+		// never leave a half-applied migration that re-runs (and possibly fails) next boot.
+		tx, err := db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, string(body)); err != nil {
+			_ = tx.Rollback()
 			return fmt.Errorf("migration %s: %w", name, err)
 		}
-		if _, err := db.ExecContext(ctx, `INSERT INTO schema_migration(name) VALUES (?)`, name); err != nil {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO schema_migration(name) VALUES (?)`, name); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+		if err := tx.Commit(); err != nil {
 			return err
 		}
 	}

--- a/internal/store/turn_sizing.go
+++ b/internal/store/turn_sizing.go
@@ -1,0 +1,41 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// ModelTurns is per-model turn counts for the model-right-sizing metric: turns that
+// produced output, and how many of those produced fewer than smallMax output tokens.
+type ModelTurns struct {
+	Model      string
+	Turns      int64
+	SmallTurns int64
+}
+
+// TurnSizing counts, per model, output-producing turns and how many produced fewer than
+// smallMax output tokens. It reads the raw per-record grain that Usage's daily GROUP BY
+// hides, so the model-right-sizing metric measures actual turns rather than day-aggregates.
+func (s *Store) TurnSizing(ctx context.Context, since time.Time, smallMax int64) ([]ModelTurns, error) {
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT model,
+            COALESCE(SUM(CASE WHEN output_tokens > 0 THEN 1 ELSE 0 END), 0) AS turns,
+            COALESCE(SUM(CASE WHEN output_tokens > 0 AND output_tokens < ? THEN 1 ELSE 0 END), 0) AS small
+        FROM usage_record
+        WHERE ts >= ? AND granularity = 'turn'
+        GROUP BY model`, smallMax, since.UTC().Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []ModelTurns
+	for rows.Next() {
+		var m ModelTurns
+		if err := rows.Scan(&m.Model, &m.Turns, &m.SmallTurns); err != nil {
+			return nil, err
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}

--- a/internal/survival/git.go
+++ b/internal/survival/git.go
@@ -1,0 +1,130 @@
+package survival
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// gitOutput runs `git -C root <args>` and returns stdout, wrapping any failure with the
+// trimmed stderr so a caller sees why git rejected the command.
+func gitOutput(ctx context.Context, root string, args ...string) ([]byte, error) {
+	//nolint:gosec // root is the user's own repo path and args are assaio-controlled literals
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", root}, args...)...)
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(errBuf.String()))
+	}
+	return out.Bytes(), nil
+}
+
+// repoRoot resolves repoPath to its git working-tree root, erroring when it is not a repo.
+func repoRoot(ctx context.Context, repoPath string) (string, error) {
+	out, err := gitOutput(ctx, repoPath, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", fmt.Errorf("%s is not a git repository: %w", repoPath, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// windowCommits is the set of commit hashes reachable from HEAD with a commit date at or
+// after since -- the commits whose surviving lines we count.
+func windowCommits(ctx context.Context, root string, since time.Time) (map[string]struct{}, error) {
+	out, err := gitOutput(ctx, root, "log", "--no-merges", "--since="+since.Format(time.RFC3339), "--format=%H")
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]struct{})
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	for sc.Scan() {
+		if h := strings.TrimSpace(sc.Text()); h != "" {
+			set[h] = struct{}{}
+		}
+	}
+	return set, sc.Err()
+}
+
+// addedAndTouched sums the lines the window's commits added (git numstat) and returns the
+// set of files they touched, for the survival blame pass. Binary edits (numstat "-") are
+// skipped.
+func addedAndTouched(ctx context.Context, root string, since time.Time) (added int64, files []string, err error) {
+	out, err := gitOutput(ctx, root, "log", "--since="+since.Format(time.RFC3339), "--numstat", "--format=")
+	if err != nil {
+		return 0, nil, err
+	}
+	seen := make(map[string]struct{})
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		fields := strings.SplitN(sc.Text(), "\t", 3)
+		if len(fields) != 3 || fields[0] == "-" { // "-" marks a binary edit: no line counts
+			continue
+		}
+		if n, e := strconv.ParseInt(fields[0], 10, 64); e == nil {
+			added += n
+		}
+		if path := numstatPath(fields[2]); path != "" {
+			if _, ok := seen[path]; !ok {
+				seen[path] = struct{}{}
+				files = append(files, path)
+			}
+		}
+	}
+	return added, files, sc.Err()
+}
+
+// survivingLines blames each still-present touched file at HEAD and counts lines whose
+// commit is in the window set -- window-authored lines still in the tree. A file git can't
+// blame (deleted or renamed away) is skipped; its lines legitimately did not survive.
+func survivingLines(ctx context.Context, root string, files []string, commits map[string]struct{}) (surviving int64, blamed int, err error) {
+	for _, f := range files {
+		out, e := gitOutput(ctx, root, "blame", "--line-porcelain", "HEAD", "--", f)
+		if e != nil {
+			if ctx.Err() != nil {
+				return surviving, blamed, ctx.Err()
+			}
+			continue // a deleted/renamed-away/binary path can't be blamed: it didn't survive
+		}
+		blamed++
+		sc := bufio.NewScanner(bytes.NewReader(out))
+		sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+		for sc.Scan() {
+			// --line-porcelain emits one "<sha> <orig> <final> ..." header per file line;
+			// content lines start with a tab and metadata with a keyword, so only a header's
+			// first token is ever a window hash. Matching the whole token fits SHA-1 and -256.
+			line := sc.Text()
+			if sp := strings.IndexByte(line, ' '); sp > 0 {
+				if _, ok := commits[line[:sp]]; ok {
+					surviving++
+				}
+			}
+		}
+		if sc.Err() != nil {
+			continue // a pathological (e.g. >8 MB) line breaks this file's scan, not the report
+		}
+	}
+	return surviving, blamed, nil
+}
+
+// numstatPath resolves a git numstat path field to the file's current path, unwrapping the
+// two rename forms git prints ("old => new" and "pre/{old => new}/post") so the blame pass
+// targets the present name, not the arrow-mangled string.
+func numstatPath(field string) string {
+	i := strings.Index(field, " => ")
+	if i < 0 {
+		return field
+	}
+	if open := strings.LastIndexByte(field[:i], '{'); open >= 0 {
+		if rel := strings.IndexByte(field[i:], '}'); rel >= 0 {
+			return field[:open] + field[i+len(" => "):i+rel] + field[i+rel+1:]
+		}
+	}
+	return field[i+len(" => "):]
+}

--- a/internal/survival/survival.go
+++ b/internal/survival/survival.go
@@ -1,0 +1,66 @@
+// Package survival correlates a project's AI activity with how much of its git history
+// survives in HEAD -- a directional, local outcome signal. It never attributes specific
+// lines to AI (assaio stores counts, not code), so it reports repo-wide survival of the
+// window's commits beside the AI lines the store recorded, a correlation to read rather
+// than a per-line AI-survival number. It is the local stepping stone toward the
+// server-stage git/issue correlation (BACKLOG B18, ROADMAP "Outcome & quality").
+package survival
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+)
+
+// Result is the directional survival picture for one repository over a window.
+type Result struct {
+	Project   string
+	RepoRoot  string
+	Since     time.Time
+	AILines   int64 // AI lines added in the window, from the assaio store (counts only)
+	GitAdded  int64 // lines the window's commits added (git numstat)
+	Surviving int64 // window-commit lines still present in HEAD (git blame)
+	// SurvivalRate is Surviving/GitAdded in 0..1, or -1 when GitAdded is 0 (undefined).
+	SurvivalRate float64
+	Commits      int // commits in the window
+	Files        int // window-touched files successfully blamed
+}
+
+// RepoRoot resolves repoPath to its git working-tree root (erroring when it is not a repo),
+// so a caller can derive the project name and look up its AI lines before Analyze.
+func RepoRoot(ctx context.Context, repoPath string) (string, error) {
+	return repoRoot(ctx, repoPath)
+}
+
+// Project is the project name Analyze reports for root -- its basename, matching how ingest
+// resolves a session's project from its git repository root.
+func Project(root string) string { return filepath.Base(root) }
+
+// Analyze computes the survival picture for the already-resolved repo root since `since`,
+// given the AI lines the store recorded for its project in the same window.
+func Analyze(ctx context.Context, root string, since time.Time, aiLines int64) (Result, error) {
+	commits, err := windowCommits(ctx, root, since)
+	if err != nil {
+		return Result{}, err
+	}
+	added, files, err := addedAndTouched(ctx, root, since)
+	if err != nil {
+		return Result{}, err
+	}
+	surviving, blamed, err := survivingLines(ctx, root, files, commits)
+	if err != nil {
+		return Result{}, err
+	}
+	rate := -1.0
+	if added > 0 {
+		rate = float64(surviving) / float64(added)
+		if rate > 1 {
+			rate = 1
+		}
+	}
+	return Result{
+		Project: Project(root), RepoRoot: root, Since: since,
+		AILines: aiLines, GitAdded: added, Surviving: surviving, SurvivalRate: rate,
+		Commits: len(commits), Files: blamed,
+	}, nil
+}

--- a/internal/survival/survival_test.go
+++ b/internal/survival/survival_test.go
@@ -1,0 +1,103 @@
+package survival
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	//nolint:gosec // test-only git driver over a t.TempDir() path, not user input
+	cmd := exec.CommandContext(context.Background(), "git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestAnalyzeCountsSurvivingWindowLines builds a tiny repo whose three commits add 8 lines
+// and leave 6 in HEAD, and checks Analyze reports GitAdded=8, Surviving=6, and the rate --
+// the whole point being that removed lines don't survive and the AI count passes through.
+func TestAnalyzeCountsSurvivingWindowLines(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.email", "t@t.test")
+	runGit(t, dir, "config", "user.name", "Test")
+
+	writeFile(t, dir, "a.txt", "l1\nl2\nl3\nl4\nl5\n")
+	runGit(t, dir, "add", "a.txt")
+	runGit(t, dir, "commit", "-m", "c1")
+
+	writeFile(t, dir, "a.txt", "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\n")
+	runGit(t, dir, "commit", "-am", "c2")
+
+	writeFile(t, dir, "a.txt", "l1\nl2\nl3\nl4\nl7\nl8\n")
+	runGit(t, dir, "commit", "-am", "c3")
+
+	ctx := context.Background()
+	root, err := RepoRoot(ctx, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := Analyze(ctx, root, time.Now().Add(-time.Hour), 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Commits != 3 {
+		t.Fatalf("Commits = %d, want 3", res.Commits)
+	}
+	if res.GitAdded != 8 {
+		t.Fatalf("GitAdded = %d, want 8 (5+3 added; the removal adds nothing)", res.GitAdded)
+	}
+	if res.Surviving != 6 {
+		t.Fatalf("Surviving = %d, want 6 (the two removed lines don't survive)", res.Surviving)
+	}
+	if res.AILines != 100 {
+		t.Fatalf("AILines = %d, want the 100 passed through", res.AILines)
+	}
+	if want := 6.0 / 8.0; res.SurvivalRate < want-1e-9 || res.SurvivalRate > want+1e-9 {
+		t.Fatalf("SurvivalRate = %v, want %v", res.SurvivalRate, want)
+	}
+}
+
+// TestNumstatPath locks the rename-path unwrapping so a renamed file is blamed at its
+// current name (else its added lines count but never survive, deflating the rate).
+func TestNumstatPath(t *testing.T) {
+	cases := map[string]string{
+		"foo.go":                "foo.go",
+		"old.go => new.go":      "new.go",
+		"src/{old => new}/f.go": "src/new/f.go",
+		"{a => b}":              "b",
+	}
+	for in, want := range cases {
+		if got := numstatPath(in); got != want {
+			t.Errorf("numstatPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestRepoRootRejectsNonRepo confirms a non-repository path errors rather than being
+// treated as an empty repo.
+func TestRepoRootRejectsNonRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if _, err := RepoRoot(context.Background(), t.TempDir()); err == nil {
+		t.Fatal("RepoRoot on a non-repo dir: want an error, got nil")
+	}
+}

--- a/internal/usage/record.go
+++ b/internal/usage/record.go
@@ -14,8 +14,11 @@ type Record struct {
 	OutputTokens     int64
 	CacheReadTokens  int64
 	CacheWriteTokens int64
-	ReasoningTokens  int64
-	DedupeKey        string
+	// ReasoningTokens is the thinking/reasoning portion that is already included in
+	// OutputTokens (an informational subset, billed at the output rate). It is never
+	// added to a token total and never priced on its own -- doing either double-counts.
+	ReasoningTokens int64
+	DedupeKey       string
 	// Member is a pseudonymized author/agent id, set by the server from a sync push;
 	// "" for purely-local usage. Never set by a parser.
 	Member string


### PR DESCRIPTION
## What & why

v0.2.0. Seven new `analyze` validators — coverage, cache-hygiene, subscription-fit,
session-taxonomy, turn-efficiency, model-right-sizing, reasoning-share (**twelve total**) —
a `survival` command that correlates a repo's git history with recorded AI lines as a
directional local outcome signal, Cline discovery across VS Code / Insiders / VSCodium /
Cursor, and a Gemini header-sessionId correctness fix. Also lands the audit fixes (reasoning
double-count, anonymized-dashboard subpath leak, server empty-dedupe_key row collapse,
config validation, movers determinism, throughput window, Cline skip-and-count, plugin I/O
robustness, boundary caps) and the max-effort code-review fixes on this branch's own new
code.

## How tested

`make test lint` green (19/19 packages, 0 lint issues); parser changes fuzzed (Cline,
Gemini); `CGO_ENABLED=0 go build ./...` passes; the new validators and `survival` verified
against real Claude + Codex data (~120k records).

## Documentation

`CHANGELOG.md` cut to `[0.2.0]`; `FEATURES.md`/`BACKLOG.md` updated; `ROADMAP.md` rebuilt as
forward-only direction; `docs/automation.md` added (git-hook / scheduled-sync recipes).

**Compatibility:** the Gemini dedupe-key change means users who ingested header-only Gemini
logs under v0.1.x should run `clear --tool gemini-cli` then `backfill` once after upgrading
(noted in the changelog).

## Code review

A max-effort multi-agent review ran over this branch: **15 confirmed findings, 14 fixed
here** (with regression tests) + 1 (the Gemini dedupe transition) handled via the
compatibility note above.
