### PR TITLE
docs: reorder the roadmap around what makes it readable, and carry it onto the page

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -2,15 +2,17 @@ name: site
 
 # The page at https://assaio.dev/ is a single static file, published by Cloudflare Workers
 # Builds straight from this repository (docs/site.md). This workflow does not deploy it; what
-# is left here is the guard, and the guard is the reason the file exists at all -- the site
-# once ended up three releases behind the binary, and nothing noticed.
+# is left here are the guards on the two claims the page makes about itself.
 #
-# Because publishing is no longer downstream of this check, a red guard no longer holds a
-# stale page back: it reports the drift after the fact rather than preventing it. That trade
-# is recorded in docs/site.md; the check still fails the branch, which is what a reviewer and
-# a release see.
+# It used to guard a third: a version stamp in the footer, which had to equal the latest tag.
+# That check existed because the page once ran three releases behind the binary. It is gone
+# because the *stamp* is gone -- the page no longer names a version at all, so there is no
+# longer a number on it that can silently fall behind. A fact worth stating once is worth
+# stating in the one place it cannot rot, and for "which version is current" that place is the
+# releases page, which the site now links instead of copying. What is left for a release to
+# check by hand is in RELEASING.md, and none of it was ever mechanical.
 #
-# Deliberately not path-filtered. The guard has to run on every push and every tag, including
+# Deliberately not path-filtered. The guards have to run on every push and every tag, including
 # the ones that do not touch site/ -- a release cut without updating the page is precisely the
 # drift this exists to catch, and a path filter would skip it silently.
 on:
@@ -28,42 +30,66 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Guards the one claim the page makes about itself that can silently rot: which version it
-  # describes. The site documents what a user can install, so it must name the latest *tag* --
-  # or the release currently being prepared, because RELEASING.md requires the page and the
-  # changelog section to be updated before the tag exists, and a check that forbade that would
-  # make the release-prep commit unmergeable on a protected branch.
-  version:
+  # The page deliberately names no version, so it cannot advertise a stale one. This check is
+  # what keeps that true: a number reintroduced here is a number somebody has to remember at
+  # every tag, and the release that forgets it is the one nobody notices. Link the releases
+  # page instead. (Version-shaped strings inside prose -- "v1.0 has to mean" -- are not stamps;
+  # this looks for a bare vX.Y.Z, which is what a stamp is.)
+  noversion:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Site must name the latest released version
+      - name: The site names no version
         run: |
           set -euo pipefail
-          claimed=$(grep -oE 'Assay report · v[0-9]+\.[0-9]+\.[0-9]+' site/index.html \
-                    | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-          latest=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          # The release being prepared, if any: the newest changelog section with no tag yet.
-          # consistency.yml is what keeps this to at most one.
-          pending=""
-          for v in $(grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '#[] '); do
-            if ! git rev-parse "v$v" >/dev/null 2>&1; then
-              pending="v$v"
-              break
-            fi
-          done
-          echo "site claims:  ${claimed:-<none>}"
-          echo "latest tag:   ${latest:-<none>}"
-          echo "being cut:    ${pending:-<none>}"
-          if [ -z "$claimed" ]; then
-            echo "::error::site/index.html carries no 'Assay report · vX.Y.Z' version stamp"
+          # grep exits 2 on a missing file and `if` reads that as "no match", so the guard would
+          # pass on a page it never opened. Every check below assumes the file was read.
+          test -f site/index.html || { echo "::error::site/index.html is missing"; exit 1; }
+          # Geometry attributes are stripped first: optimized path data writes implicit separators
+          # (`d="M12.5.5…"`, which SVGO emits by default), and a dotted triple there is coordinates,
+          # not a version. sed keeps line count, so grep -n still reports the real line.
+          if sed -E 's/ (d|points|viewBox|transform)="[^"]*"//g' site/index.html \
+             | grep -nE '\bv?[0-9]+\.[0-9]+\.[0-9]+\b'; then
+            echo "::error file=site/index.html::The page names a version. It deliberately does not:"
+            echo "::error file=site/index.html::a stamp here has to be updated at every tag, and the release that forgets is the one nobody catches."
+            echo "::error file=site/index.html::Link https://github.com/assaio/assaio/releases instead of copying the number."
             exit 1
           fi
-          if [ -n "$latest" ] && [ "$claimed" != "$latest" ] && [ "$claimed" != "$pending" ]; then
-            echo "::error::site/index.html describes $claimed but the latest release is $latest."
-            echo "::error::The site documents what a user can install. Update it, or cut the release first."
-            echo "::error::(A version being prepared is allowed once CHANGELOG.md carries its section.)"
-            exit 1
+
+  # The page's closing line promises it loads nothing -- no fonts, no analytics, no third-party
+  # requests -- and that is a claim about the artifact, not a preference. It takes one pasted
+  # embed to make it false, and a marketing badge is exactly the shape that arrives as one, so
+  # the promise gets a check rather than a reviewer's memory. Inline the asset, or change the
+  # sentence: both are fine, silently breaking it is not.
+  selfcontained:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: The site fetches nothing at render time
+        run: |
+          set -euo pipefail
+          test -f site/index.html || { echo "::error::site/index.html is missing"; exit 1; }
+          fail=0
+          # Every attribute a browser fetches without being asked, in each quoting form it can
+          # take. Checking only src="..." would miss srcset=, a single-quoted src, and an
+          # unquoted one -- three ways a pasted embed arrives.
+          if grep -nEo '(src|srcset|poster|data)=("[^"]*"|'"'"'[^'"'"']*'"'"'|[^ >]+)' site/index.html \
+             | grep -vE '=["'"'"']?data:'; then
+            echo "::error file=site/index.html::A fetched attribute points somewhere other than a data: URI."
+            fail=1
           fi
+          # A <link> fetches on nearly every rel -- icon, manifest, preload, stylesheet. Listing
+          # the ones that fetch means forgetting one, so this allows only the two that do not.
+          if grep -nE '<link[^>]*>' site/index.html \
+             | grep -vE 'rel="(canonical|alternate)"' | grep -v 'href="data:'; then
+            echo "::error file=site/index.html::A <link> fetches a subresource."
+            fail=1
+          fi
+          if grep -nE '@import|url\(["'"'"']?(https?:)?//' site/index.html; then
+            echo "::error file=site/index.html::A stylesheet rule pulls a remote resource."
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            echo "::error file=site/index.html::The colophon promises this page loads nothing. Inline the asset, or change the promise."
+          fi
+          exit $fail

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -33,7 +33,7 @@ the source-depth matrix (`B58`, `B59`, `B69`, `B81`, `B82`, `B83`, all v0.5), an
 annotations with per-kind-of-work stratification (`B80`, v0.6) alongside the GitHub Copilot
 CLI parser (`B53`, v0.6). See [CHANGELOG.md](CHANGELOG.md) and [FEATURES.md](FEATURES.md).
 
-## Now — "Correctness lockdown"
+## Shipped — "Correctness lockdown"
 
 Nothing new is built on top of a surface that is known to be wrong. Every item here is a
 defect in something already shipped, each with the reproduction that found it, and they are
@@ -48,20 +48,83 @@ store, a team-server push that could never correct a partial figure, and an acti
 correction that could not reach a stored row at all. **The milestone is closed** — what a
 later review finds opens a new pool below rather than reopening this one.
 
-## Next — "Calibrated measurement"
+## Now — "Calibrated measurement"
 
 The guard the v0.12 class of bug needs, which provenance and coverage cannot provide. `B137`,
 the conservation and metamorphic suite, shipped in v0.14 as `internal/calibration`, and `B19`,
 the offline reconciliation against a vendor's own export, shipped after it — both are in
-[CHANGELOG.md](CHANGELOG.md). What they left open is `B144`, and the one contribution that
-would close it is the same one `B19` needs: a redacted real capture.
+[CHANGELOG.md](CHANGELOG.md). Two items sit here and they are open for opposite reasons: `B139`
+needs nobody's data and is the largest error still open in the `$` figure, while `B144` cannot be
+closed here at all — it needs a redacted real capture, the same contribution `B19`'s column
+aliases need. The milestone also depends on `B116` and `B118`, which live in the code-health pool
+below because they are corrections to a shipped mechanism rather than calibration work; `B116` is
+additionally a v1.0 condition.
 
+- [ ] **B139 · nothing notices when the price table falls behind the models in use** — M ·
+  both — moved here from the v0.13 review pool, because a price table that has fallen behind is
+  a figure checked against nothing, which is what this milestone is for. v0.13 refreshed the
+  vendored LiteLLM snapshot and the acute case is gone: on the maintainer's store 45.5% of tokens
+  (22.7B of 49.8B) had no price because `claude-opus-5` was absent, and the window's estimate rose
+  $23,750.98 → $39,203.40 once it had one. **The mechanism that let it happen is untouched.**
+  Three parts, none of them a bigger asterisk.
+  (1) A refresh is a release chore with no owner and no test that fails when the table lags the
+  models in a real store — a stale table is indistinguishable from a complete one from inside,
+  which is why five weeks of drift produced no signal at all. (2) The `*` marker discloses the
+  condition wherever cost renders but **never quantifies it**: "includes unpriced usage" reads
+  the same at 0.1% and at 45%, and the reader cannot tell which they are looking at. (3)
+  `doctor` prints `pricing: N models, snapshot <date>` — a fact about the table, not about
+  *your* window — and `--strict` does not fire on it, so the largest single source of error in
+  the headline number stayed invisible to the gate that exists to catch exactly that. `B34`
+  proposes the validator; this is the diagnostic, the disclosure and the release gate, and it
+  wants a decision on what unpriced share is worth failing on.
 - [ ] **B144 · calibrate Gemini CLI and Cline against a real capture** — S · both — both are
   calibrated today against a *constructed* sample in the source's shape, because the maintainer's
   machine holds neither a Gemini chat log carrying token counts nor a Cline install. A
   constructed trace proves the reading; only a real one also proves the shape is still what the
   vendor writes, and each trace already declares which it is (`capture: real|constructed`). Needs
   one redacted capture per source from anybody who runs them.
+
+## Next — "Worth opening twice"
+
+The four items that decide whether the analysis already shipped reaches anybody. Not a detour
+from depth: this is the only milestone that answers the questions
+[ROADMAP.md](ROADMAP.md#how-we-prioritize) names as the measure of whether the project is
+working — how long from install to a first useful insight, whether someone runs a second report
+the following week, how often a finding is acted on. Every one of these sat in an unscheduled
+pool until now, which is exactly why none of them ever came up for air.
+
+- [ ] **B148 · which finding is worth acting on** — M · both — nineteen reads render as
+  nineteen reads. A reader with a wall of verdicts acts on none of them, which makes breadth
+  actively harmful past some count. Rank each finding by what is already knowable —
+  evidence strength and coverage (both already on every `Confidence`), how much of the window
+  the finding's subject reaches, and whether anything can be done about it — and surface the
+  few worth a week's attention while the rest stay one click away. Deliberately **not** a
+  score: the ranking is an ordering with its reasons shown, and a window whose findings are
+  all weak ranks nothing rather than promoting the least weak one. Expected impact stays out
+  of v1 — it needs the outcome link (`B84`, `B96`) and guessing it would be the fabricated
+  number this project refuses.
+- [ ] **B11 · weekly digest** — S/M · both — `digest --weekly`: markdown summary
+  (top movers, verdict changes, anomalies) fit for cron/launchd; delivery stays the
+  user's own script (mail, Slack, …). It reads the window every other surface reads and reports
+  what *moved* rather than restating what is, which is what makes a second one worth receiving;
+  the ordering (`B148`) is what decides which movers lead it.
+- [ ] **B149 · a shareable assay** — M · both — `assaio share --since 30d` renders a single
+  image or page fit to post publicly: tool and model mix, the token/cost trend, a few
+  findings, and the coverage and confidence behind them. Redaction is the feature, not a
+  flag: no repository names, no member names, no file paths, no identifiers, ever, and a
+  preview before anything is written so the person sees exactly what would leave their
+  machine. Carries the line the dashboard already earns — prompts and source code were not
+  collected. The open question is what a figure means once its labels are gone: "your
+  heaviest project" with no name is still a shape someone may recognize, so the redaction
+  rule needs stating before the renderer, not after.
+- [ ] **B152 · a label the person does not have to type** — S/M · both — `mark` works and
+  goes unused, because annotating a session is a chore nobody does twice. The store already
+  holds `git_branch` on every row, and a branch called `fix/…` or `feat/…` states the task
+  class its author already chose. Derive a **suggested** label from what is there — branch
+  prefix first, PR metadata once the evidence graph lands — and keep the derivation visible
+  and overridable: a derived label carries its source, never merges silently into a
+  hand-made one, and a repository with no convention yields nothing rather than a guess. The
+  closed vocabularies and the never-synced rule stay exactly as they are.
 
 ## Then — "Everything the logs already say"
 
@@ -81,16 +144,6 @@ on, since a link to a merged pull request is only as good as the session it link
   legitimately looks like thrashing, so every detector ships with what it cannot distinguish.
   Store cost is the open question: a step row per turn is a different size class from today's
   daily aggregate and needs its bound and cleanup settled before it lands.
-- [ ] **B148 · which finding is worth acting on** — M · both — nineteen reads render as
-  nineteen reads. A reader with a wall of verdicts acts on none of them, which makes breadth
-  actively harmful past some count. Rank each finding by what is already knowable —
-  evidence strength and coverage (both already on every `Confidence`), how much of the window
-  the finding's subject reaches, and whether anything can be done about it — and surface the
-  few worth a week's attention while the rest stay one click away. Deliberately **not** a
-  score: the ranking is an ordering with its reasons shown, and a window whose findings are
-  all weak ranks nothing rather than promoting the least weak one. Expected impact stays out
-  of v1 — it needs the outcome link (`B84`, `B96`) and guessing it would be the fabricated
-  number this project refuses.
 - [ ] **B107 · Codex cache-write tokens are never read** — S · solo —
   `payload.info.total_token_usage.cache_write_input_tokens` is reported on every Codex
   `token_count` and `usage.Record` gets no value for it. **Measure before claiming a
@@ -316,8 +369,6 @@ leaderboard from it.
   aggregated bands, pseudonymized.
 - [ ] **B41 · team efficiency spread** — M · team — distribution bands of turn-efficiency
   signals across members; "the team needs prompting practice" without naming anyone.
-- [ ] **B25 · Postgres backend** — L · team — once a single SQLite file stops being enough
-  for a central store.
 
 ## Later — "Cost truth, policy & interoperability"
 
@@ -353,7 +404,8 @@ The one milestone that keeps a version number, because there the number *is* the
 a frozen contract over an uncalibrated measurement is a stable wrong answer, which is worse than
 a breaking correct one. The six conditions are spelled out in
 [ROADMAP.md](ROADMAP.md#what-v10-has-to-mean); the contract freeze is the last of them, not the
-first.
+first. `B24` used to sit here and no longer does — its own entry says it is not a v1.0
+condition, so it moved to the reserved pool below rather than contradicting itself in place.
 
 - [ ] **B23 · protocol freeze** — M · both — declare the exec plugin protocols (parser,
   metric, rule), the canonical event and signal contracts and the sync API stable under semver,
@@ -362,6 +414,15 @@ first.
   it will not be the last, so freezing the store would make every future correction a breaking
   change and create pressure to leave a wrong number in place. It stays internally versioned
   and migratable — a promise about correctability, not the absence of one.
+## Pool — reserved: waiting on a condition, not on time
+
+Neither of these is scheduled, and neither is dropped. Each waits for a fact to become true —
+a scale that does not exist yet, and a mechanism that has not been chosen — so listing them
+anywhere else would misrepresent them as work anyone is about to pick up. `B24` in particular
+was under the v1.0 heading while its own text said it is not a v1.0 condition.
+
+- [ ] **B25 · Postgres backend** — L · team — once a single SQLite file stops being enough
+  for a central store. Not before: the current shape has not been shown to hurt.
 - [ ] **B24 · in-process plugin API (research first)** — L · both — **no longer a v1.0
   condition**: it is a research question, not a readiness bar. The mechanism is **not**
   decided, and native Go plugins are explicitly not a v1 requirement: they need cgo, do not
@@ -446,14 +507,6 @@ first.
 
 ## Pool — CLI & DX
 
-- [ ] **B152 · a label the person does not have to type** — S/M · both — `mark` works and
-  goes unused, because annotating a session is a chore nobody does twice. The store already
-  holds `git_branch` on every row, and a branch called `fix/…` or `feat/…` states the task
-  class its author already chose. Derive a **suggested** label from what is there — branch
-  prefix first, PR metadata once the evidence graph lands — and keep the derivation visible
-  and overridable: a derived label carries its source, never merges silently into a
-  hand-made one, and a repository with no convention yields nothing rather than a guess. The
-  closed vocabularies and the never-synced rule stay exactly as they are.
 - [ ] **B45 · TUI** — L · both — interactive terminal dashboard (validators +
   project drill), the flagship DX piece once the small wins land.
 - [ ] **B46 · completions + man pages** — S · both — cobra generators, shipped via
@@ -476,9 +529,6 @@ first.
   chrome, statusline words, the 18 explain pages); what remains is translating it and choosing
   how a locale is selected. Data-derived validator text stays out of scope: translating it
   needs message templates for the interpolated numbers.
-- [ ] **B11 · weekly digest** — S/M · both — `digest --weekly`: markdown summary
-  (top movers, verdict changes, anomalies) fit for cron/launchd; delivery stays the
-  user's own script (mail, Slack, …).
 - [ ] **B86 · contributor entry points** — S · both — public issues cut from the top
   backlog items, labels (`good first issue`, `help wanted`, `connector`, `metric`,
   `parser-drift`, `research-needed`, `privacy-review`), Discussions categories, and a short
@@ -486,15 +536,6 @@ first.
 
 ## Pool — dashboard
 
-- [ ] **B149 · a shareable assay** — M · both — `assaio share --since 30d` renders a single
-  image or page fit to post publicly: tool and model mix, the token/cost trend, a few
-  findings, and the coverage and confidence behind them. Redaction is the feature, not a
-  flag: no repository names, no member names, no file paths, no identifiers, ever, and a
-  preview before anything is written so the person sees exactly what would leave their
-  machine. Carries the line the dashboard already earns — prompts and source code were not
-  collected. The open question is what a figure means once its labels are gone: "your
-  heaviest project" with no name is still a shape someone may recognize, so the redaction
-  rule needs stating before the renderer, not after.
 - [ ] **B145 · what the faceplate ratio is called, and whether it belongs there** — S ·
   both — *needs a decision, not a patch.* Each cell shows `Purity` as a gauge plus a bare
   `0.46` now captioned "index". A reader has no way to learn what the index measures, and
@@ -526,7 +567,6 @@ a tool used by one organization is usually better served by an out-of-tree
   cache{read,write}}`, `cost`, `modelID`, and — richest of any candidate — the `edit` tool
   persists a structured `filediff{additions,deletions,patch}`, so lines +/- are stored
   directly, no diff parsing. The best activity target after the current four.
-- [ ] **B54 · Factory droid** — M — session-granularity local logs (per ROADMAP).
 - [ ] **B88 · Antigravity — activity-only, no cost** — M · both — research verified
   (2026-07-31), and the answer is unusual enough to record: Google Antigravity stores a lot
   locally and **no token counts anywhere**. Its CLI keeps one SQLite database per
@@ -544,7 +584,6 @@ a tool used by one organization is usually better served by an out-of-tree
   reason to refuse the source. Decision record first, code second.
 - [ ] **B55 · Cursor (Admin API)** — M — local storage verified to lack token counts;
   vendor-aggregate granularity, tagged as such.
-- [ ] **B56 · Kiro** — M — only if its logs turn out to carry real token data.
 - [ ] **B151 · what a plugin declares, and a badge that goes red when a vendor moves** — M ·
   both — two halves of the same gap. A plugin today is verified for *protocol* conformance
   (`plugins verify`, `metrics verify`) and declares nothing about itself: whether it touches
@@ -571,11 +610,6 @@ a tool used by one organization is usually better served by an out-of-tree
   `tmp/*/chats`), and tokens are in a raw-API `usageMetadata` object, not Gemini's
   normalized `tokens{…}`. It also persists tool-call args, so unlike Gemini it carries edit
   activity. Needs its own parser, not the Gemini one; verify a real sample first.
-- [ ] **B62 · Continue** — M — `~/.continue` dev-data event logs reportedly carry
-  token counts; verify shape via a connector issue before building.
-- [ ] **B63 · Goose** — M — local session JSONL reportedly carries usage; verify.
-- [ ] **B64 · Amp / Crush** — M — local thread/session storage; token presence
-  unverified for both; research first (connector issues).
 - [ ] **B65 · Cursor local activity source** — M — `~/.cursor/ai-tracking/`'s
   AI-code-tracking database is a potential **activity-only** source (AI-attributed
   code, no token counts — Cursor's local storage is verified to lack them). Would ship
@@ -586,6 +620,18 @@ a tool used by one organization is usually better served by an out-of-tree
   prompt_tokens,completion_tokens,total_tokens,cost}`, `time` in epoch seconds, no session
   id or cache split); `.aider.chat.history.md` is markdown-only. No structured per-edit field
   — Aider auto-commits, so lines +/- come from git, not the logs.
+- [ ] **B154 · unverified connector candidates — one intake, not five entries** — M · both —
+  five tools whose local storage nobody here has read: **Factory droid** (session-granularity
+  logs), **Kiro**, **Continue** (`~/.continue` dev-data event logs reportedly carry token
+  counts), **Goose** (local session JSONL reportedly carries usage) and **Amp / Crush** (local
+  thread/session storage, token presence unverified for both). Each held its own line for
+  months and each said the same sentence — *verify a real sample first* — which is a wish list
+  wearing a backlog's clothes, and it made the connector pool the longest in this file while
+  none of it was actionable. They collapse into one intake: a candidate leaves this line and
+  earns its own id **when somebody opens a connector issue with a redacted sample showing token
+  counts exist**, and not before. Supersedes `B54`, `B56` and `B62`–`B64`, whose ids are
+  retired rather than reused. The candidates above keep their entries because a verified
+  on-disk format is a different kind of fact from a rumour about one.
 
 ## Pool — code health (from earlier reviews)
 
@@ -668,23 +714,10 @@ they wait behind features but keep the growing metric surface maintainable.
 ## Pool — from the v0.13 whole-codebase review
 
 Same rule as the pool below: reproduced against the maintainer's own store before being
-written down. What v0.13 fixed is in [CHANGELOG.md](CHANGELOG.md) and not repeated here.
+written down. What v0.13 fixed is in [CHANGELOG.md](CHANGELOG.md) and not repeated here. `B139`
+left this pool for the calibration milestone above — an unwatched price table is a figure checked
+against nothing, which is that milestone's subject rather than a cleanup.
 
-- [ ] **B139 · nothing notices when the price table falls behind the models in use** — M ·
-  both — v0.13 refreshed the vendored LiteLLM snapshot and the acute case is gone: on the
-  maintainer's store 45.5% of tokens (22.7B of 49.8B) had no price because `claude-opus-5` was
-  absent, and the window's estimate rose $23,750.98 → $39,203.40 once it had one. **The
-  mechanism that let it happen is untouched.** Three parts, none of them a bigger asterisk.
-  (1) A refresh is a release chore with no owner and no test that fails when the table lags the
-  models in a real store — a stale table is indistinguishable from a complete one from inside,
-  which is why five weeks of drift produced no signal at all. (2) The `*` marker discloses the
-  condition wherever cost renders but **never quantifies it**: "includes unpriced usage" reads
-  the same at 0.1% and at 45%, and the reader cannot tell which they are looking at. (3)
-  `doctor` prints `pricing: N models, snapshot <date>` — a fact about the table, not about
-  *your* window — and `--strict` does not fire on it, so the largest single source of error in
-  the headline number stayed invisible to the gate that exists to catch exactly that. `B34`
-  proposes the validator; this is the diagnostic, the disclosure and the release gate, and it
-  wants a decision on what unpriced share is worth failing on.
 - [ ] **B140 · a Claude `<synthetic>` message is counted as a turn** — S · solo — Claude Code
   writes locally-generated assistant messages (API errors, refusals to continue) with
   `"model": "<synthetic>"` and an all-zero usage block. **Measured:** 551 of 163,976 records

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,12 +68,13 @@ each of these describes the version being cut — a page or a table that lags th
 how an honesty-first product starts making false claims about itself:
 
 - `site/index.html` — the page served at <https://assaio.dev/>. The supported-tool list, the
-  command list, validator counts, and any "on the roadmap" wording about something that has
-  since shipped. **Update it before tagging**, not after: the site describes what a user can
-  install, and CI fails once the tag exists while the page still names the previous version.
-  The version guard accepts a page naming the release being prepared as long as `CHANGELOG.md`
-  already carries that section — so the page bump and the prepared section must reach `main` in
-  the same push, though not necessarily in the same commit.
+  command list, validator counts, the **roadmap section** (an item that shipped leaves the "next
+  release" panel), and any "on the roadmap" wording about something that has since shipped.
+  **Update it before tagging**, not after. The page deliberately names no version — that stamp
+  was removed precisely because it was a chore attached to every tag, and CI now fails if a
+  version reappears on it (see [docs/site.md](docs/site.md)) — so nothing here is enforced
+  mechanically any more. It is a read-through, and it is on this list because it was once
+  skipped.
   It deploys itself from `main` (see [docs/site.md](docs/site.md)), so a merge publishes it
   immediately — there is no separate step that would prompt a review.
 - `FEATURES.md` — a row per user-facing capability, with the release it arrived in.
@@ -117,11 +118,17 @@ build-provenance attestations.
    user-facing highlights; put any breaking change under a **Breaking** heading first.
 3. Verify provenance of one artifact:
    `gh attestation verify <artifact> -o assaio`.
-4. Load <https://assaio.dev/> and confirm it names the version just published. The site
-   redeploys on every push to `main`, so this checks the deploy went through, not the copy —
-   the copy was checked before tagging. Do not skip it: publishing is not gated on the
-   version guard (see [docs/site.md](docs/site.md#what-that-costs-stated-plainly)), so this
-   load is what actually catches a page that went live naming the wrong release.
+4. Confirm the deploy actually ran. The page names no version, so there is no stamp to eyeball —
+   and a release that changed nothing on the page would leave nothing to eyeball anyway. Compare
+   the bytes instead, which works either way:
+
+   ```sh
+   diff <(curl -fsSL https://assaio.dev/) site/index.html && echo "live page matches this commit"
+   ```
+
+   The site redeploys on every push to `main`, and publishing is not gated on any check (see
+   [docs/site.md](docs/site.md#what-that-costs-stated-plainly)), so this is the only thing
+   standing between a failed upload and a page nobody looks at again for weeks.
 
 ## Rules
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,8 +87,9 @@ target, golden file, drift canary and capability gate this project had built. It
 a person reading the code, and the same read found that the Codex parser silently drops about
 half of its added lines (`B119`). See [why calibration now leads](#why-calibration-comes-before-correlation).
 
-So **correctness lockdown** and **calibrated measurement** come first, then the remaining depth
-in the logs, and the evidence graph waits behind all three. Correlation on top of an uncalibrated measurement does not produce a wrong
+So **correctness lockdown** and **calibrated measurement** come first, then making what is
+already measured worth acting on, then the remaining depth in the logs, and the evidence graph
+waits behind all four. Correlation on top of an uncalibrated measurement does not produce a wrong
 number — it produces a *more persuasive* wrong number, which is the one failure this project
 cannot absorb.
 
@@ -104,8 +105,9 @@ answer does not come from the parser, is the next milestone rather than a later 
 | **Trust the dataset** ✓ | Before `assaio` advises anything, it shows what it read, what it missed, and how sure it is | shipped in v0.5: every validator carries coverage + confidence as data, format drift is detected instead of silently under-reporting, `doctor --strict` fails a cron job, every source publishes its real depth, and a first run needs no config (`B58`, `B59`, `B69`, `B81`, `B82`, `B83`) |
 | **Intent** ✓ | Metrics can be read per kind of work | shipped in v0.6: a session can be labeled task class / outcome / difficulty, any metric stratified by it, and unlabeled data stays fully counted (`B80`) |
 | **Correctness lockdown** ✓ | Every known wrong number, false green and silent data loss in a shipped surface is closed before anything new is built on top | shipped across v0.13 and v0.14, each defect with the reproduction that found it. **v0.13 closed the eight that carried a wrong number or destroyed data**: Codex's dropped file creations (`B119`), the DSN that can open the wrong database (`B120`), `clear` leaving a store that no `backfill` refills (`B121`), `--labels` ignoring every scope flag (`B122`), `doctor --strict` exiting 0 on a broken store (`B123`), units chosen before rounding (`B127`), a real cost rendered `$0` (`B131`) and a rework rate that can exceed 100% (`B132`). **v0.14 closed the remaining ten** — non-ASCII paths leaving the survival rate and a failed blame read as "did not survive" (`B124`, `B125`), worktrees collapsing into a project named `..` (`B126`), an eight-day "seven-day" window (`B128`), unattributed usage counted as a project (`B129`), anonymous CSV rows (`B130`), the unbounded plugin timestamp (`B133`), `init --db` importing to one store and reporting from another (`B134`), a share totalled in the wrong dimension (`B135`) and a full gauge beside a withheld verdict (`B136`) — **and four the same review found**: a repeated Claude transcript line counted twice (460 added and 656 removed lines on the maintainer's corpus), a superseded sub-agent aggregate left in the store, a team-server push that could never correct a partial figure, and — the one that gates the rest — an activity correction that `MAX` made unable to reach a stored row at all, which is the second half of `B116` |
-| **Calibrated measurement** | Every figure assaio publishes has been checked against something that is not assaio, and a semantic mis-read fails a test instead of shipping | the conservation and metamorphic suite, shipped in v0.14 as `internal/calibration`: adjudicated traces for all five sources whose totals were counted outside the parser, accounting invariants that run over a whole real corpus, metamorphic properties holding two encodings of one fact to one total, and a cross-surface rule (`B137`) — it found two defects in the flagship parser and one over-claim in the capability matrix on its first run; the offline reconciliation against a vendor's own billing or usage export, reporting scope mismatch and unexplained delta rather than forcing agreement (`B19`), which computes the scope overlap before any delta and names only the causes that have evidence; still open, a parser fix that can find and rebuild every stored row it invalidates (`B116`, `B118`), and a real capture for the two sources calibrated against a constructed one (`B144`) |
-| **Everything the logs already say** | Without a server, a repository or a credential, `assaio` reads every signal the local logs carry, proves the reading is right, and turns it into more conclusions than any vendor dashboard draws from the same file | every source's unread fields are inventoried and either extracted or documented as deliberately skipped, done in v0.10 ([the audit](docs/extending.md#what-each-sources-log-carries-and-what-assaio-reads)); what it found is extracted (`B107`–`B114`, of which the cache tier and miss cause shipped in v0.12 as `B108`); the activity gap closes where a log carries the data (`B39`, `B72`); the local-view metrics land as one file each with their caveats (`B28`–`B37`, `B02`, `B78`, `B79`); and a parser proves itself against evidence it did not generate, so a mis-read fails a test instead of shipping, shipped in v0.14 (`B137`); and the session stops being only a total — a content-free timeline of what the agent actually did, read for the patterns that make a session expensive, so "why did this cost so much" has an answer (`B147`), with the findings ordered by what is worth acting on rather than rendered as a wall (`B148`) |
+| **Calibrated measurement** | Every figure assaio publishes has been checked against something that is not assaio, and a semantic mis-read fails a test instead of shipping | the conservation and metamorphic suite, shipped in v0.14 as `internal/calibration`: adjudicated traces for all five sources whose totals were counted outside the parser, accounting invariants that run over a whole real corpus, metamorphic properties holding two encodings of one fact to one total, and a cross-surface rule (`B137`) — it found two defects in the flagship parser and one over-claim in the capability matrix on its first run; the offline reconciliation against a vendor's own billing or usage export, reporting scope mismatch and unexplained delta rather than forcing agreement (`B19`), which computes the scope overlap before any delta and names only the causes that have evidence; still open, the price table that falls behind the models a store actually holds with nothing to notice (`B139`) — the largest error still open in the `$` figure, and the one of these that needs nobody else's data — a parser fix that can find and rebuild every stored row it invalidates (`B116`, `B118`), and a real capture for the two sources calibrated against a constructed one (`B144`) |
+| **Worth opening twice** | A first run produces something worth acting on this week, and a reason to come back the next one | findings are ordered by what is worth a week's attention rather than rendered as a wall of equals, with the ordering's reasons shown and nothing promoted when everything is weak (`B148`); a digest fit for cron says what moved without anyone opening a terminal (`B11`); an assay can be shared publicly with redaction as the feature rather than a flag (`B149`); and the label that makes every metric comparable per kind of work stops being a chore nobody does twice (`B152`) |
+| **Everything the logs already say** | Without a server, a repository or a credential, `assaio` reads every signal the local logs carry, proves the reading is right, and turns it into more conclusions than any vendor dashboard draws from the same file | every source's unread fields are inventoried and either extracted or documented as deliberately skipped, done in v0.10 ([the audit](docs/extending.md#what-each-sources-log-carries-and-what-assaio-reads)); what it found is extracted (`B107`–`B114`, of which the cache tier and miss cause shipped in v0.12 as `B108`); the activity gap closes where a log carries the data (`B39`, `B72`); the local-view metrics land as one file each with their caveats (`B28`–`B37`, `B02`, `B78`, `B79`); and a parser proves itself against evidence it did not generate, so a mis-read fails a test instead of shipping, shipped in v0.14 (`B137`); and the session stops being only a total — a content-free timeline of what the agent actually did, read for the patterns that make a session expensive, so "why did this cost so much" has an answer (`B147`) — which the milestone above is what keeps readable, since every detector this adds is one more finding competing for the same week's attention |
 | **Evidence graph** | You can see which AI sessions produced commits and pull requests, what happened in review and CI, and how sure `assaio` is about every link | the canonical event contract ([ADR 0007](docs/adr/0007-canonical-event-contract.md)) and the signal catalog ([ADR 0008](docs/adr/0008-signal-catalog.md)) exist, both shipped; local git commit metadata is a content-free observation, shipped, and GitHub PR/review/check metadata is not yet; the conformance corpus that defines what an honest link is, shipped ahead of the engine ([ADR 0010](docs/adr/0010-attribution-conformance-corpus.md)); attribution edges carry method, confidence, alternatives and ambiguity; ambiguous stays ambiguous; `outcomes` shows the funnel with its unattributed share and `evidence explain` says why a link was or was not made; and what a change costs *after* it is written — review rounds, CI repair, revert risk, cost per merged and per surviving change — becomes countable, age-matched against human work of the same age (`B92`, `B94`, `B85`, `B18`, `B21`, `B153`, `B100`–`B104`) |
 | **Harness intelligence** | You learn which agent configuration and workflow changes actually helped, and each finding comes with one reversible experiment | agent config artifacts are inventoried without storing their content; cohorts can be compared before and after a harness version changed; recommendations are deterministic rules carrying evidence, one action, a follow-up metric and a review window, and abstain when outcome coverage is thin — never an LLM narrating a dashboard; and which model earns which kind of work is answered from your own comparable sessions, with a floor below which it names no winner (`B95`, `B96`, `B84`, `B97`, `B87`, `B150`, `B17`, `B44`) |
 | **Team, without surveillance** | A team self-hosts it, sees adoption and delivery outcomes, and cannot build a leaderboard from it | authenticated, resumable sync with retention and roles; adoption read as activation → retention → breadth, in bands with a cohort floor (`B22`, `B09`, `B40`, `B41`) |
@@ -150,6 +152,65 @@ Billing is not a universal oracle and the roadmap should not pretend otherwise: 
 a line count, an edit attribution, a per-session allocation, or anything on a flat-rate plan.
 Those need their own external checks — git is the ground truth for changed lines, and a
 controlled session with a known shape is the ground truth for event grain.
+
+There is a third check, it is the cheapest of the three, and it is why `B139` sits on this
+milestone rather than in a cleanup pool. Every `$` assaio prints is a token count multiplied by a
+**vendored price table**, and the table is the half nothing watches. v0.13 refreshed the snapshot
+and found that **45.5% of the tokens on the maintainer's own store — 22.7B of 49.8B — carried no
+price at all**, because the model doing most of the work was missing from it; that window's
+estimate moved $23,750.98 → $39,203.40 once it had one. The parser was right, the arithmetic was
+right, and the headline figure was far too low for five weeks. Every property of the v0.12 class
+of bug is present: a stale table is indistinguishable from a complete one from the inside, the
+`*` marker that discloses it reads identically at 0.1% and at 45%, and `doctor --strict` — the
+gate whose entire job is catching this — does not fire on it. Quantifying the unpriced share
+wherever cost renders, and failing the gate at a share worth failing on, is a calibration
+question, not a polish one.
+
+### Why an ordering is not a detour from depth
+
+The sequence above puts "make the findings readable" between calibration and the deeper reading
+of the logs, which looks like a contradiction of the rule that depth wins when the two compete.
+It is a different trade. That rule is about depth versus **breadth** — one more shallow vendor
+against a deeper read of the sources already supported. An ordering is neither: it decides
+whether the depth already shipped reaches anybody at all.
+
+Nineteen reads render as nineteen reads. A reader facing a wall of equally weighted verdicts acts
+on none of them, which means each additional metric is worth *less* than the one before it past
+some count — the single place in this project where adding a correct measurement can subtract
+value. `B147` sharpens that rather than softening it: every detector it adds is one more finding
+competing for the same week of attention.
+
+It is also the only milestone that answers the questions [How we prioritize](#how-we-prioritize)
+names as the measure of whether any of this is working — how long from install to a first useful
+insight, whether someone runs a second report the following week, how often a finding is acted on
+and whether the metric it named actually moved. Those have been the stated success criteria since
+the first version of this document, and nothing on the roadmap has promised them until now.
+
+### What is being worked on now
+
+The table is the intended sequence; this is the current position in it. Deliberately with no
+version number, for the reason given above the table — the next tag is simply the next minor, and
+what it carries is a list, not a schedule. Items drop out of it, and a bug report can add one.
+
+- `B139` — quantify the unpriced share wherever a cost renders, and let `doctor --strict` fail on
+  it. The one open calibration item that needs nobody else's data.
+- `B148` — order the findings, show the ordering's reasons, and promote nothing when the whole
+  window is weak.
+- `B146` — validator figures group thousands, so the dashboard stops disagreeing with the report
+  table beside it.
+- `B115` — a fourth reason for `insufficient`, so a verdict stops blaming a source for history
+  parsed by a build that could not capture the field yet.
+- `B145` — decide what the faceplate's bare ratio is called, or whether it belongs there at all.
+
+Two of the milestone's remaining items are not on that list and are not blocked either: `B116`
+and `B118`, which decide whether a parser fix can reach the rows it invalidates and whether a
+cross-source rate may keep its denominator. `B116` is a v1.0 condition in its own right, so it
+outlives this list rather than waiting behind it.
+
+What genuinely cannot be finished here is **blocked on data, not on time**. One redacted Gemini
+CLI or Cline capture closes `B144`; one redacted vendor export settles the column aliases
+`reconcile` binds by. Neither can be manufactured on this machine, and both are the most useful
+thing anybody running those tools can contribute.
 
 ### What v1.0 has to mean
 
@@ -371,6 +432,10 @@ a packaged GitHub Action (the `check` gate plus a PR comment — `B12`), shell c
 man pages (`B46`), data exports (OpenMetrics for Grafana, ndjson/parquet for data teams —
 `B47`), and growing the i18n scaffold into real locales as people ask (`B08`).
 
+Two of those moved onto the *Worth opening twice* milestone rather than staying here: the weekly
+digest (`B11`) and the label nobody has to type (`B152`). A daily habit is what that promise is
+made of, so they belong to a promise rather than to a pool.
+
 Every one of those is a **surface over the same analysis**, never a second implementation of
 it. A number that differs between `report`, the dashboard, the TUI and MCP is a bug, and the
 cheapest way to avoid it is to keep the computation in `internal/analyze` and `internal/report`
@@ -425,6 +490,13 @@ and tool-error loops, long sessions that correlate with rework, a plan that does
 itself — and it carries what was observed, on how much data, at what confidence, one concrete
 action, the metric that will show whether it worked, and the window after which to look again.
 It can be dismissed as not relevant, and that dismissal sticks.
+
+The first step of that chain needs no outcome link and is therefore not waiting behind one:
+ordering the findings by what is already knowable (`B148`) is `explain → suggest` with the
+suggestion still withheld. It says *look at this one first, and here is why it outranks the
+others* without claiming what acting on it would be worth — the expected-impact figure stays out
+until an outcome can supply it, because guessing it is exactly the fabricated number this project
+refuses.
 
 The order matters: facts → metrics → confidence → rule → suggestion, and only then an
 optional LLM *explaining* a suggestion that already exists. Never raw numbers → LLM →

--- a/docs/site.md
+++ b/docs/site.md
@@ -12,21 +12,63 @@ directory goes and under which domains — deployment configuration, not a build
 whether to install something, so a feature that exists only on `main` must not appear on it —
 `[Unreleased]` in the changelog means "installing the latest release does not give you this."
 
-A CI job enforces the part that can be checked mechanically: the `Assay report · vX.Y.Z` stamp
-in the hero must equal the highest `v*` tag in the repo. It runs on every push, PR and tag —
-deliberately not path-filtered, because a release cut *without* touching the page is exactly
-the drift worth catching.
+**The page names no version at all, and a CI job holds it to that.** It used to carry an
+`Assay report · vX.Y.Z` stamp in the footer, guarded against the highest `v*` tag, because the
+page had once run three releases behind the binary. Both the stamp and that guard are gone, and
+the reasoning is worth keeping: a version copied onto the page is a fact that has to be updated
+at every tag, and the release that forgets to update it is, by definition, the one nobody
+notices. A fact worth stating once belongs in the one place it cannot rot. For "which version is
+current" that place is the releases page, which the site now links instead of copying.
 
-One version ahead is also allowed, and only one: the release being prepared, recognised as the
-newest `## [X.Y.Z]` section in `CHANGELOG.md` that has no tag yet. Without that exception the
-rule would be unsatisfiable — [RELEASING.md](../RELEASING.md#the-changelog-flow-exact-tag-coupled)
-requires the page and the changelog section to be updated *before* the tag is cut, and `main` is
-protected, so a prep commit that can never be green could never be merged and the tag could never
-exist. The `consistency` workflow is what keeps the pending version to exactly one.
+What replaced the guard is its inverse: `site.yml` fails if a bare `X.Y.Z` appears anywhere in
+`site/index.html`. Reintroducing a stamp is therefore a deliberate act with a red check attached,
+not an easy convenience that quietly creates a chore.
 
-Everything else is a review norm, listed in [RELEASING.md](../RELEASING.md#the-public-surface-check-before-every-tag):
-the supported-tool list, the command list, validator counts, and any "on the roadmap" wording
-about something that has since shipped.
+This removes a mechanical check without removing the obligation behind it. Everything a release
+still has to confirm by hand is listed in
+[RELEASING.md](../RELEASING.md#the-public-surface-check-before-every-tag) — the supported-tool
+list, the command list, validator counts, and the roadmap section. None of that was ever
+mechanical; the version stamp was the only part that was, and it was also the only part that had
+to change on a release that changed nothing else on the page. "On the roadmap" wording about
+something that has since shipped belongs to the same read-through.
+
+### Saying what does not exist yet
+
+That rule governs what the page presents as **available**. The roadmap section is the one place
+it may name work that does not exist, and it earns that only by leaving no room to misread: the
+section states up front that nothing in it is built, the next release carries an explicit *not
+released yet* marker, and the installable build is a link to the releases page rather than a
+claim. Anywhere else on the page, describing a capability is claiming it ships today.
+
+That section names no release either, which is the same rule applied twice. It says *the next
+release*, not `v0.16.0` — the ordering is the information, and a number would only add something
+to keep in sync. This also keeps the page consistent with
+[ROADMAP.md](../ROADMAP.md#the-next-milestones), which deliberately assigns no version to a
+promise for its own stated reason.
+
+The one exception is `v1.0`, which the section uses as the **name of a milestone** rather than as
+a stamp — it is what that promise has been called since the roadmap's first draft, and it names
+no release date and no release contents. The guard draws the same line by requiring three
+components: `v1.0` passes, `v1.0.0` does not.
+
+What the section does need at release time is the obvious thing: an item that shipped leaves it.
+That is a review norm in [RELEASING.md](../RELEASING.md#the-public-surface-check-before-every-tag),
+alongside the tool and command lists, and it is the same judgement they need.
+
+### The page fetches nothing
+
+The colophon ends by promising the page loads nothing: no fonts, no analytics, no third-party
+requests. That is a property of the artifact, so `site.yml` checks it. Every fetching attribute —
+`src`, `srcset`, `poster`, `data` — must hold a `data:` URI, in any quoting form including none,
+because `src="…"` alone would miss the three other ways a pasted embed writes it. A `<link>` may
+only be `canonical` or `alternate`, or carry a `data:` URI: nearly every other `rel` fetches, so
+the check allows the two that do not rather than trying to list the ones that do. And no
+`@import` or `url(//…)`, protocol-relative included. The check exists because the sentence is one
+pasted embed away from being false, and a marketing badge is precisely the shape that arrives as
+one. The Product Hunt badge in the hero is the worked
+example: the official SVG, both themes, inlined. Inlining it also froze its upvote counter, so
+the counter was removed rather than shipped stale — a page arguing that a number should never
+look more certain than it is cannot display a stale one.
 
 ## How it deploys
 
@@ -41,17 +83,18 @@ a fact about the project, and keeping it in the repository is what stops it from
 setting in a dashboard nobody remembers — which is how the site deploy stayed broken for five
 releases.
 
-`site.yml` no longer deploys. It runs the version guard on every push, tag and pull request,
-and nothing else.
+`site.yml` no longer deploys. It runs the two page guards — no version named, nothing fetched
+at render time — on every push, tag and pull request, and nothing else.
 
 ### What that costs, stated plainly
 
-Publishing is no longer downstream of the guard. Cloudflare builds from the commit, not from a
-green check, so a `main` whose page names the wrong version **will go live** and the guard will
-report it afterwards rather than hold it back. The check still fails the branch, which is what
-a reviewer and the release checklist see — but "the site cannot be published stale" is no
-longer true, and the release-time step in
-[RELEASING.md](../RELEASING.md#after-the-workflow-finishes) is now the thing that catches it.
+Publishing is no longer downstream of the guards. Cloudflare builds from the commit, not from a
+green check, so a `main` carrying a stale page **will go live** and the guards will report it
+afterwards rather than hold it back. They still fail the branch, which is what a reviewer and the
+release checklist see — but "the site cannot be published stale" is not true, and the
+release-time step in [RELEASING.md](../RELEASING.md#after-the-workflow-finishes) is what catches
+it. Removing the version stamp shrank what can go stale in the first place, which is a better
+answer than a guard: what is not written down cannot fall behind.
 
 The alternative is to deploy from GitHub Actions with two repository secrets, which keeps the
 guard upstream of publication. Both work; this one trades that guarantee for having no

--- a/site/index.html
+++ b/site/index.html
@@ -79,6 +79,17 @@ code{font:400 .9em/1 var(--mono)}
 .copybtn:hover{color:var(--fg); background:var(--rule-soft)}
 .note{margin:.85rem 0 0; font-size:.8125rem; color:var(--faint); max-width:36rem}
 
+/* product hunt badge — inlined, both themes, so the page still requests nothing */
+.ph{display:inline-block; margin-top:1.6rem; line-height:0}
+.ph .ph-l{display:block}
+.ph .ph-d{display:none}
+@media (prefers-color-scheme:dark){
+  :root[data-theme="auto"] .ph .ph-l{display:none}
+  :root[data-theme="auto"] .ph .ph-d{display:block}
+}
+:root[data-theme="dark"] .ph .ph-l{display:none}
+:root[data-theme="dark"] .ph .ph-d{display:block}
+
 .gauge{border:1px dashed var(--rule); border-radius:3px; background:var(--cell); padding:1.35rem 1.4rem 1.5rem}
 .gauge .g-sub{margin:.15rem 0 0; font:500 .6875rem/1.4 var(--mono); letter-spacing:.12em; text-transform:uppercase; color:var(--faint)}
 .g-read{font:600 clamp(1.5rem,3.4vw,2rem)/1 var(--mono); letter-spacing:-.02em; margin:1.5rem 0 0; color:var(--faint)}
@@ -184,6 +195,19 @@ td .g{color:var(--signal)} td .w{color:var(--amber)} td .m{color:var(--faint)}
 .why p{margin:0 0 1rem; color:var(--dim)}
 .why strong{color:var(--fg); font-weight:600}
 
+/* roadmap */
+.next{border:1px solid var(--signal); border-radius:3px; background:var(--cell); padding:1.35rem 1.4rem}
+.nh{display:flex; align-items:center; gap:.75rem; flex-wrap:wrap; margin-bottom:1.15rem}
+.nv{font:600 1rem/1 var(--mono); letter-spacing:-.02em; color:var(--signal)}
+.nt{font:500 .625rem/1 var(--mono); letter-spacing:.14em; text-transform:uppercase; color:var(--amber); border:1px solid var(--amber); border-radius:2px; padding:.4rem .5rem}
+.next ul{margin:0; padding-left:1.1rem}
+.next li{margin:0 0 .8rem; font-size:.9375rem; color:var(--dim)}
+.next li:last-child{margin-bottom:0}
+.next li b{color:var(--fg); font-weight:600}
+.seq{margin-top:1.25rem}
+.card .st{display:block; margin-bottom:.6rem; font:500 .625rem/1 var(--mono); letter-spacing:.14em; text-transform:uppercase; color:var(--faint)}
+.card.now .st{color:var(--signal)}
+
 /* partner */
 .partner{display:grid; grid-template-columns:repeat(auto-fit,minmax(16rem,1fr)); gap:1.25rem}
 .partner .p{border:1px solid var(--rule); border-radius:3px; padding:1.35rem 1.4rem}
@@ -199,8 +223,6 @@ td .g{color:var(--signal)} td .w{color:var(--amber)} td .m{color:var(--faint)}
 .colo nav a{font:500 .75rem/1 var(--mono); letter-spacing:.1em; text-transform:uppercase; color:var(--dim); text-decoration:none; border-bottom:1px solid var(--rule); padding-bottom:.25rem}
 .colo nav a:hover{color:var(--fg); border-color:var(--fg)}
 .colo p{margin:.5rem 0 0; max-width:54rem}
-.rel{display:inline-flex; align-items:center; gap:.5rem; font:500 .6875rem/1 var(--mono); letter-spacing:.12em; text-transform:uppercase; border:1px solid var(--rule); border-radius:2px; padding:.45rem .65rem; color:var(--dim); text-decoration:none; margin-bottom:1.1rem}
-.rel:hover{color:var(--fg); border-color:var(--fg)}
 
 @media (max-width:56rem){
   .hero{grid-template-columns:1fr; gap:2.5rem}
@@ -222,6 +244,7 @@ td .g{color:var(--signal)} td .w{color:var(--amber)} td .m{color:var(--faint)}
     <a href="#sources">Sources</a>
     <a href="#adapt">Extend</a>
     <a href="#install">Install</a>
+    <a href="#roadmap">Roadmap</a>
     <a href="https://github.com/assaio/assaio">GitHub</a>
   </nav>
   <button class="tog" id="tog" type="button">Theme</button>
@@ -253,6 +276,24 @@ td .g{color:var(--signal)} td .w{color:var(--amber)} td .m{color:var(--faint)}
         </div>
       </div>
       <p class="note">About sixty seconds to your own numbers: <code>init</code> detects your tools, shows every directory it will read <em>before</em> reading it, imports, and prints the report. Want to look before importing anything? <code>assaio-agent demo</code> runs the full reports on bundled sample data.</p>
+      <a class="ph" href="https://www.producthunt.com/products/assaio?utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-assaio" target="_blank" rel="noopener noreferrer">
+        <svg class="ph-l" width="202" height="54" viewBox="0 0 202 54" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Find assaio on Product Hunt">
+          <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <rect stroke="#FF6154" stroke-width="1" fill="#FFFFFF" x="0.5" y="0.5" width="201" height="53" rx="10"></rect>
+            <text font-family="Helvetica-Bold, Helvetica" font-size="9" font-weight="bold" fill="#FF6154"><tspan x="53" y="20">FIND US ON</tspan></text>
+            <text font-family="Helvetica-Bold, Helvetica" font-size="21" font-weight="bold" fill="#FF6154"><tspan x="52" y="40">Product Hunt</tspan></text>
+            <g transform="translate(11.000000, 12.000000)"><path d="M31,15.5 C31,24.0603917 24.0603917,31 15.5,31 C6.93960833,31 0,24.0603917 0,15.5 C0,6.93960833 6.93960833,0 15.5,0 C24.0603917,0 31,6.93960833 31,15.5" fill="#FF6154"></path><path d="M17.4329412,15.9558824 L17.4329412,15.9560115 L13.0929412,15.9560115 L13.0929412,11.3060115 L17.4329412,11.3060115 L17.4329412,11.3058824 C18.7018806,11.3058824 19.7305882,12.3468365 19.7305882,13.6308824 C19.7305882,14.9149282 18.7018806,15.9558824 17.4329412,15.9558824 M17.4329412,8.20588235 L17.4329412,8.20601152 L10.0294118,8.20588235 L10.0294118,23.7058824 L13.0929412,23.7058824 L13.0929412,19.0560115 L17.4329412,19.0560115 L17.4329412,19.0558824 C20.3938424,19.0558824 22.7941176,16.6270324 22.7941176,13.6308824 C22.7941176,10.6347324 20.3938424,8.20588235 17.4329412,8.20588235" fill="#FFFFFF"></path></g>
+          </g>
+        </svg>
+        <svg class="ph-d" width="202" height="54" viewBox="0 0 202 54" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Find assaio on Product Hunt">
+          <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+            <rect stroke="#221D21" stroke-width="1" fill="#221D21" x="0.5" y="0.5" width="201" height="53" rx="10"></rect>
+            <text font-family="Helvetica-Bold, Helvetica" font-size="9" font-weight="bold" fill="#EEF2FF"><tspan x="53" y="20">FIND US ON</tspan></text>
+            <text font-family="Helvetica-Bold, Helvetica" font-size="21" font-weight="bold" fill="#EEF2FF"><tspan x="52" y="40">Product Hunt</tspan></text>
+            <g transform="translate(11.000000, 12.000000)"><path d="M31,15.5 C31,24.0603917 24.0603917,31 15.5,31 C6.93960833,31 0,24.0603917 0,15.5 C0,6.93960833 6.93960833,0 15.5,0 C24.0603917,0 31,6.93960833 31,15.5" fill="#FFFFFF"></path><path d="M17.4329412,15.9558824 L17.4329412,15.9560115 L13.0929412,15.9560115 L13.0929412,11.3060115 L17.4329412,11.3060115 L17.4329412,11.3058824 C18.7018806,11.3058824 19.7305882,12.3468365 19.7305882,13.6308824 C19.7305882,14.9149282 18.7018806,15.9558824 17.4329412,15.9558824 M17.4329412,8.20588235 L17.4329412,8.20601152 L10.0294118,8.20588235 L10.0294118,23.7058824 L13.0929412,23.7058824 L13.0929412,19.0560115 L17.4329412,19.0560115 L17.4329412,19.0558824 C20.3938424,19.0558824 22.7941176,16.6270324 22.7941176,13.6308824 C22.7941176,10.6347324 20.3938424,8.20588235 17.4329412,8.20588235" fill="#221D21"></path></g>
+          </g>
+        </svg>
+      </a>
     </div>
     <aside class="gauge">
       <p class="eyebrow">Assay verdict</p>
@@ -574,6 +615,44 @@ assaio-agent dashboard  # one self-contained HTML file</pre><p class="ip">Prefer
     </div>
   </section>
 
+  <!-- ROADMAP ────────────────────────────────────────────────────────────── -->
+  <section class="sec" id="roadmap">
+    <div class="wrap">
+      <div class="sec-head"><h2>Where this is going</h2><p class="eyebrow">direction, not commitment</p></div>
+      <p class="intro">
+        This is the order the work is meant to happen in — no dates, no guarantees, and any item
+        can be reshaped or dropped when a bug report or a pull request makes the case.
+        <strong>Nothing in the next-release panel is built yet.</strong> The milestones under it
+        run from one already half-shipped to one that is years of nobody's promise, and each card
+        says which part is which. What you can install is the
+        <a href="https://github.com/assaio/assaio/releases">latest release</a>; the
+        <a href="https://github.com/assaio/assaio/blob/main/FEATURES.md">feature inventory</a> is
+        what that actually gives you.
+      </p>
+      <div class="next">
+        <div class="nh"><span class="nv">The next release</span><span class="nt">not released yet</span></div>
+        <ul>
+          <li><b>A cost figure says how much of itself is missing.</b> Every <code>$</code> is a token count times a vendored price table, and a model the table doesn't know renders a blank behind an asterisk that reads identically at 0.1% and at 45%. The share becomes a number, and <code>doctor --strict</code> can fail on it.</li>
+          <li><b>Nineteen reads stop arriving as nineteen equals.</b> Findings get an order and the order shows its reasons — and a window whose findings are all weak promotes none of them rather than crowning the least weak one.</li>
+          <li><b>A count reads the same on every surface.</b> Validator figures group thousands, so the dashboard stops printing <code>16400 tokens</code> beside a report table printing <code>16,400</code>.</li>
+          <li><b>"Insufficient" stops blaming the wrong thing.</b> A verdict with no coverage says nothing in the window can answer it — even when the real cause is history parsed by an older build, which <code>backfill</code> would fix. Two different facts, two different sentences.</li>
+          <li><b>The faceplate's bare ratio gets a name, or goes.</b> <code>STRONG · 0.46</code> reads as a contradiction when nothing says what the index measures.</li>
+        </ul>
+      </div>
+      <div class="cards seq">
+        <div class="card now"><span class="st">Now · part shipped</span><h3>Calibrated measurement</h3><p>Every figure checked against something that is <em>not</em> assaio. <strong>Shipped:</strong> the conservation and metamorphic suite, and offline <code>reconcile</code> against a vendor's own export. <strong>Open:</strong> the price table nothing watches, a parser fix that can repair the history it invalidates, and a real captured sample for the two sources calibrated against a constructed one.</p></div>
+        <div class="card"><span class="st">Next</span><h3>Worth opening twice</h3><p>A first run produces something worth acting on this week, and a reason to come back the next one: ordered findings, a digest fit for cron, an assay shareable in public with redaction as the feature, and a label nobody has to type.</p></div>
+        <div class="card"><span class="st">Then</span><h3>Everything the logs already say</h3><p>Read every signal the local logs carry and draw more conclusions from it than any vendor dashboard draws from the same file — including the session as a <em>sequence</em> rather than a total, so "why was this one expensive" has an answer.</p></div>
+        <div class="card"><span class="st">After that</span><h3>Evidence graph</h3><p>Which sessions produced which commits and pull requests, what happened in review and CI, and how sure assaio is about every link. Ambiguous stays ambiguous, and what a change costs <em>after</em> it is written becomes countable.</p></div>
+        <div class="card"><span class="st">Then</span><h3>Harness intelligence</h3><p>Whether changing an <code>AGENTS.md</code>, a skill or a model actually helped — deterministic rules carrying their evidence and one reversible experiment, never an LLM narrating a dashboard.</p></div>
+        <div class="card"><span class="st">After that</span><h3>Team, without surveillance</h3><p>A team self-hosts it, sees adoption and delivery outcomes, and cannot build a leaderboard from it. Adoption read as activation → retention → breadth, in bands, with a cohort floor.</p></div>
+        <div class="card"><span class="st">Later</span><h3>Cost truth &amp; interoperability</h3><p>The credentialed billing pull once the offline import has proved itself, long-context pricing, a mapping onto the OpenTelemetry GenAI conventions with content dropped by default, and a connector SDK.</p></div>
+        <div class="card"><span class="st">v1.0</span><h3>Measurements worth depending on</h3><p>Every claimed capability calibrated, the two deep sources reconciled against outside evidence, no known wrong number open, and a correction that can reach history. The contracts freeze last, not first — a frozen contract over an uncalibrated measurement is a stable wrong answer.</p></div>
+      </div>
+      <p class="more">Two of those are blocked on <b>data rather than on time</b>, and neither can be manufactured here: calibrating Gemini CLI and Cline against a <em>real</em> capture needs one redacted session log from somebody who runs them, and the column aliases <code>reconcile</code> binds by need one redacted vendor export. Both are the most useful thing anyone can contribute right now. The full reasoning — why calibration comes before correlation, and what v1.0 has to mean — is in <a href="https://github.com/assaio/assaio/blob/main/ROADMAP.md">ROADMAP.md</a>; the ranked pool with an id per item is <a href="https://github.com/assaio/assaio/blob/main/BACKLOG.md">BACKLOG.md</a>.</p>
+    </div>
+  </section>
+
   <!-- WHY ────────────────────────────────────────────────────────────────── -->
   <section class="sec" id="why">
     <div class="wrap">
@@ -611,7 +690,6 @@ assaio-agent dashboard  # one self-contained HTML file</pre><p class="ip">Prefer
 </main>
 
 <footer class="wrap colo">
-  <a class="rel" href="https://github.com/assaio/assaio/blob/main/CHANGELOG.md">Assay report · v0.15.0 → changelog</a>
   <nav>
     <a href="https://github.com/assaio/assaio">GitHub</a>
     <a href="https://github.com/assaio/assaio/releases">Releases</a>


### PR DESCRIPTION
The roadmap's macro order stands — calibration before correlation is argued in the document and the argument still holds. What had drifted was inside it.

## Roadmap

- **`B139` moves onto "Calibrated measurement"** from the v0.13 review pool. An unwatched price table is a figure checked against nothing, which is that milestone's subject rather than a cleanup — 45.5% of tokens on the maintainer's store carried no price, and the estimate moved `$23,750.98 → $39,203.40` once the model had a row. It is also the only item there that needs nobody else's data, which matters because the rest of the milestone is blocked on a capture this machine cannot produce.
- **New milestone, "Worth opening twice"** — an ordering over findings (`B148`), a cron-fit digest (`B11`), a shareable assay (`B149`), a label nobody has to type (`B152`). Every one sat in an unscheduled pool, which is exactly why none came up for air, while the document's own success criteria — time to a first insight, a second report next week, a finding acted on — had nothing promising them. `B148` leads and precedes `B147`: nineteen reads nobody acts on are the one place where adding a correct measurement subtracts value.
- **Two structural contradictions removed.** `B25` was in a milestone *and* in the theme saying it is reserved until the current shape hurts; `B24` sat under the v1.0 heading while its own text says it is not a v1.0 condition.
- **Five unverified connector candidates collapse into `B154`.** Each said "verify a real sample first" — a wish list wearing a backlog's clothes. `B54`, `B56`, `B62`–`B64` are retired, never reused.
- Stage labels in `BACKLOG.md` shift by one: the closed correctness-lockdown milestone was still labelled *Now*.

## Site

- A **"Where this is going"** section carrying the same sequence, with stage labels matched to `BACKLOG`'s headings so the two cannot be read against each other. The next release is named by its contents, not a number.
- **The version stamp leaves the page.** It was the only fact on the site that had to be updated at every tag, and the release that forgets it is by definition the one nobody notices. "Which version is current" now lives only on the releases page, which the site links. Its CI guard is replaced by the inverse — a version reappearing on the page fails.
- **The Product Hunt badge is the official SVG inlined in both themes**, not an embed, so the colophon's promise that the page loads nothing stays true. Inlining froze its upvote counter, so the counter is removed rather than shipped stale.

## Guards

`site.yml` now runs two checks instead of one, both verified against twelve positive and negative cases:

| case | noversion | selfcontained |
|---|---|---|
| clean page | pass | pass |
| remote favicon / manifest | pass | **fail** |
| `srcset` / single-quoted / unquoted `src` | pass | **fail** |
| protocol-relative `url(//…)` | pass | **fail** |
| version stamp, bare or `v`-prefixed | **fail** | pass |
| optimized SVG path data (`d="M12.5.5…"`) | pass | pass |
| milestone name `v1.0` | pass | pass |
| missing file | **fail** | **fail** |

`RELEASING.md`'s post-release step now diffs the live bytes against the commit instead of eyeballing a stamp that no longer exists.

## Deliberately not done

Removing the version job drops the only *mechanical* detection that a release shipped without updating the site. That trade is recorded in `docs/site.md`: what is not written on the page cannot fall behind, and the remaining read-through is in `RELEASING.md`. Nothing here needs a `CHANGELOG` entry — no user-facing behaviour changed.
