### PR TITLE
chore(release): prepare v0.17.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Discussion.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-08-11
+
 ### Added
 - **The extension surface stops being weaker than the core it extends (`B155`).** Six fields of
   the prepared `Input` never crossed the metric-plugin boundary — `windowStart`,
@@ -1524,7 +1526,8 @@ Discussion.
 - Cost honesty throughout: every `$` disclosed as an estimate at public
   pay-as-you-go API prices; unpriced models render an honest blank, never a fake `$0`.
 
-[Unreleased]: https://github.com/assaio/assaio/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/assaio/assaio/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/assaio/assaio/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/assaio/assaio/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/assaio/assaio/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/assaio/assaio/compare/v0.13.0...v0.14.0


### PR DESCRIPTION
Retitles `[Unreleased]` to `[0.17.0] - 2026-08-11`, recreates an empty `[Unreleased]`, and adds the compare links. Separate commit because `make release` refuses to tag while `[Unreleased]` still carries entries, and `main` is protected.