### PR TITLE
fix(site): link the reference at the path the host serves, and check that

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -115,6 +115,34 @@ jobs:
           done < <(find site -type f -name '*.html' | sort)
           exit $fail
 
+  # Workers Assets serves site/reference.html at /reference and 307s the extension away, so a
+  # link or a canonical naming the file points at a redirect rather than at the page. That is
+  # invisible in review and in a local browser, where opening the file works either way -- it
+  # only shows up against the deployed site. This is the same failure mode as the version stamp:
+  # a fact about the artifact that nothing checked. Every internal link and canonical has to name
+  # a path the host actually serves.
+  servedpaths:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Every internal link names a path the host serves
+        run: |
+          set -euo pipefail
+          fail=0
+          while IFS= read -r ref; do
+            case "$ref" in
+              /) continue ;;   # index.html, served at the root
+              *.html) echo "::error::$ref names a file; Workers Assets serves it without the extension"; fail=1; continue ;;
+            esac
+            # Anything else must be an extensionless page or a real asset in the directory.
+            if [ ! -f "site/${ref#/}.html" ] && [ ! -f "site/${ref#/}" ]; then
+              echo "::error::$ref is linked but site/ serves no such page or asset"
+              fail=1
+            fi
+          done < <(grep -ohE '(href|content)="(https://assaio\.dev)?/[^"#]*"' site/*.html \
+                   | sed -E 's/.*="(https:\/\/assaio\.dev)?([^"]*)"/\2/' | sort -u)
+          exit $fail
+
   # A link to assaio.dev rendered as a bare grey line on LinkedIn and every other reader for as
   # long as the page shipped without an og:image -- the tags were all there except the one that
   # makes a card exist. It is not covered by `selfcontained`: a crawler fetches og:image out of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,11 @@ Discussion.
   prefix. Masking what is structurally not a version is the same move the guard already made for
   SVG geometry attributes.
 - **854 bytes of stylesheet for the deleted roadmap section** left `site/index.html` with it.
+- **Every internal link and canonical names a path the host actually serves.** Workers Assets
+  serves `site/reference.html` at `/reference` and `307`s the extension away, so the first cut
+  of the reference page pointed its own canonical at a redirect — correct in review and in a
+  browser opened on the file, wrong against the deployed site. A new `servedpaths` job checks
+  it, because that is a fact about the artifact and nothing was reading it.
 
 ## [0.17.0] - 2026-08-11
 

--- a/docs/site.md
+++ b/docs/site.md
@@ -14,6 +14,11 @@ read by something that is **not** the browser rendering the page:
   from what the binary would write. It publishes what can be enumerated — every signal, source,
   validator, command, flag, configuration key and metric-contract field — so the hand-written
   page never has to list any of it. Regenerate with `make docs`; do not edit it.
+  **It is served at `/reference`, not `/reference.html`**: Workers Assets drops the extension and
+  `307`s the file name away, the same handling that serves `index.html` at `/`. A link or a
+  canonical naming the file therefore points at a redirect — which looks correct in review and in
+  a browser opened on the file, and is only wrong against the deployed site. The `servedpaths`
+  job holds every internal link and canonical to a path the host actually serves.
 
 - **`og.png`** — the card a shared link renders as. Every Open Graph tag was present except
   this one, so LinkedIn and the rest showed a bare grey line; a `data:` URI cannot stand in,

--- a/internal/docs/html.go
+++ b/internal/docs/html.go
@@ -5,7 +5,9 @@ import "strings"
 // HTML renders the reference as one self-contained page. It is generated and committed as
 // site/reference.html, which is why it names no version: a served file may not carry a stamp
 // that has to be updated at every tag (docs/site.md), and the schema version belongs in the
-// JSON, where a tool reads it.
+// JSON, where a tool reads it. Every URL below drops the ".html": Cloudflare Workers Assets
+// serves the file at /reference and 307s the extension away, so a canonical naming the file
+// would point at a redirect.
 func HTML(ref *Reference) []byte {
 	var b strings.Builder
 	b.WriteString(head)
@@ -36,9 +38,9 @@ const head = `<!doctype html>
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>assaio reference — every signal, source, validator, command and setting</title>
 <meta name="description" content="The enumerable surfaces of assaio, generated from the binary's own registries: the signal catalog, the source-depth matrix, the metric validators, the command tree, the configuration keys and the metric-plugin protocol.">
-<link rel="canonical" href="https://assaio.dev/reference.html">
+<link rel="canonical" href="https://assaio.dev/reference">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://assaio.dev/reference.html">
+<meta property="og:url" content="https://assaio.dev/reference">
 <meta property="og:title" content="assaio reference">
 <meta property="og:description" content="Every signal, source, validator, command and setting — generated from the binary, not transcribed.">
 <meta property="og:image" content="https://assaio.dev/og.png">

--- a/site/index.html
+++ b/site/index.html
@@ -236,7 +236,7 @@ td .g{color:var(--signal)} td .w{color:var(--amber)} td .m{color:var(--faint)}
     <a href="#sources">Sources</a>
     <a href="#adapt">Extend</a>
     <a href="#install">Install</a>
-    <a href="/reference.html">Reference</a>
+    <a href="/reference">Reference</a>
     <a href="https://github.com/assaio/assaio">GitHub</a>
   </nav>
   <button class="tog" id="tog" type="button">Theme</button>
@@ -535,7 +535,7 @@ td .g{color:var(--signal)} td .w{color:var(--amber)} td .m{color:var(--faint)}
         <div class="cmd"><b><span data-claim="command.statusline">statusline</span></b><span>One ambient line for your status bar: today's tokens, AI lines, cost basis and data age. Read-only, never fails loudly.</span></div>
         <div class="cmd"><b><span data-claim="command.serve">serve</span> · <span data-claim="command.sync">sync</span></b><span>Self-hosted team server and the push to it — pseudonymous by default, on infrastructure you control.</span></div>
         <div class="cmd"><b><span data-claim="command.doctor">doctor</span> · <span data-claim="command.status">status</span></b><span>Detected tools, resolved log roots, store size, the per-source depth matrix, and format-drift canaries. <code>doctor --strict</code> exits non-zero on suspected drift — for cron.</span></div>
-        <div class="cmd"><b><span data-claim="command.docs">docs</span></b><span>Everything this binary can enumerate about itself — signals, sources, validators, commands, settings, the plugin protocol — as JSON or as a page. The <a href="/reference.html">published reference</a> is generated from it, and a check fails the build when this site and the binary disagree.</span></div>
+        <div class="cmd"><b><span data-claim="command.docs">docs</span></b><span>Everything this binary can enumerate about itself — signals, sources, validators, commands, settings, the plugin protocol — as JSON or as a page. The <a href="/reference">published reference</a> is generated from it, and a check fails the build when this site and the binary disagree.</span></div>
         <div class="cmd"><b><span data-claim="command.plugins">plugins</span> · <span data-claim="command.metrics">metrics</span></b><span><code>list</code> / <code>verify</code> out-of-tree exec parser, metric and rule plugins — nothing stored.</span></div>
         <div class="cmd"><b><span data-claim="command.config">config</span> · <span data-claim="command.clear">clear</span> · <span data-claim="command.compact">compact</span></b><span>Print the effective config; delete stored data with an explicit scope and <code>--yes</code>; return freed pages to the filesystem.</span></div>
       </div>
@@ -626,7 +626,7 @@ assaio-agent dashboard  # one self-contained HTML file</pre><p class="ip">Prefer
         What you can install today is the
         <a href="https://github.com/assaio/assaio/releases">latest release</a>; the
         <a href="https://github.com/assaio/assaio/blob/main/FEATURES.md">feature inventory</a> says
-        what that gives you, and the <a href="/reference.html">reference</a> is generated from the
+        what that gives you, and the <a href="/reference">reference</a> is generated from the
         binary itself — every signal, source, validator, command and setting it actually has.
       </p>
     </div>
@@ -671,7 +671,7 @@ assaio-agent dashboard  # one self-contained HTML file</pre><p class="ip">Prefer
 <footer class="wrap colo">
   <nav>
     <a href="https://github.com/assaio/assaio">GitHub</a>
-    <a href="/reference.html">Reference</a>
+    <a href="/reference">Reference</a>
     <a href="https://github.com/assaio/assaio/releases">Releases</a>
     <a href="https://github.com/assaio/assaio/blob/main/CHANGELOG.md">Changelog</a>
     <a href="https://github.com/assaio/assaio/blob/main/ROADMAP.md">Roadmap</a>

--- a/site/reference.html
+++ b/site/reference.html
@@ -5,9 +5,9 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>assaio reference — every signal, source, validator, command and setting</title>
 <meta name="description" content="The enumerable surfaces of assaio, generated from the binary's own registries: the signal catalog, the source-depth matrix, the metric validators, the command tree, the configuration keys and the metric-plugin protocol.">
-<link rel="canonical" href="https://assaio.dev/reference.html">
+<link rel="canonical" href="https://assaio.dev/reference">
 <meta property="og:type" content="website">
-<meta property="og:url" content="https://assaio.dev/reference.html">
+<meta property="og:url" content="https://assaio.dev/reference">
 <meta property="og:title" content="assaio reference">
 <meta property="og:description" content="Every signal, source, validator, command and setting — generated from the binary, not transcribed.">
 <meta property="og:image" content="https://assaio.dev/og.png">


### PR DESCRIPTION
Workers Assets serves `site/reference.html` at **`/reference`** and `307`s the extension away — the same handling that serves `index.html` at `/`. The first cut of the reference page pointed its own `canonical`, its `og:url` and every link at `/reference.html`.

That is the failure mode this release exists to remove, in a new place: it looks correct in review, and it looks correct in a browser opened on the file. It is only wrong against the deployed site, which is why nothing caught it — verified against the live deploy after #17 merged:

```
$ curl -sI https://assaio.dev/reference.html | head -2
HTTP/2 307
location: /reference
```

So the URLs move, and a new `servedpaths` job holds every internal `href` and every `assaio.dev` URL in a served page to a path `site/` actually publishes. Negative control: reintroducing `href="/reference.html"` turns it red.

`docs/site.md` records the handling rule, so the next page added to `site/` does not rediscover it.