### PR TITLE
chore(release): prepare v0.18.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Discussion.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-08-11
+
 ### Added
 - **The published surfaces are generated from the binary, or checked against it (`B161`).**
   `assaio-agent docs export --format json|html` projects the live registers into one document —
@@ -1609,7 +1611,8 @@ Discussion.
 - Cost honesty throughout: every `$` disclosed as an estimate at public
   pay-as-you-go API prices; unpriced models render an honest blank, never a fake `$0`.
 
-[Unreleased]: https://github.com/assaio/assaio/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/assaio/assaio/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/assaio/assaio/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/assaio/assaio/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/assaio/assaio/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/assaio/assaio/compare/v0.14.0...v0.15.0


### PR DESCRIPTION
Moves the `[Unreleased]` entries under `## [0.18.0]` and adds the compare link, so the tag describes exactly what it contains.

**Minor rather than patch**: the release adds a user-facing command (`docs`) and a published page — the same shape v0.17.0's `digest` had.

Nothing else changes. `make release` refuses to tag while `[Unreleased]` still holds entries, which is why this is its own PR.