### PR TITLE
chore(release): prepare v0.21.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Discussion.
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-13
+
 ### Added
 
 - **The step timeline has readers.** `analyze` gains two detectors over the sequence stored in
@@ -1807,7 +1809,8 @@ Discussion.
 - Cost honesty throughout: every `$` disclosed as an estimate at public
   pay-as-you-go API prices; unpriced models render an honest blank, never a fake `$0`.
 
-[Unreleased]: https://github.com/assaio/assaio/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/assaio/assaio/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/assaio/assaio/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/assaio/assaio/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/assaio/assaio/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/assaio/assaio/compare/v0.17.0...v0.18.0


### PR DESCRIPTION
Step 2 of the changelog flow in RELEASING.md: retitle `[Unreleased]` to `## [0.21.0] - 2026-08-13`, recreate an empty `[Unreleased]` above it, and add the two compare links.

`make release` refuses to tag until both hold — a `## [0.21.0]` section exists and `[Unreleased]` carries no leftovers — so this is the commit that unlocks the tag. No code changes.

Contents of the release are in #28.