### PR TITLE
fix(agent): keep the reserve caveat inside the card, and format the post for where it is pasted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ Discussion.
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-08-17
+
+### Fixed
+
+- **`share`: the profile frame printed its own caveat over the card's footer.** The block
+  declared a fixed allowance for a line that wraps, so on a 1:1 reel the axis disclaimer ran
+  past the body band and landed on `assaio.dev`, the hashtag and the limit line — the three
+  things that exist to qualify everything above them. The scene now sizes itself to the space
+  it has, the way the poster already did, so an oversized stack shrinks instead of overflowing.
+- **`share`: the suggested post is formatted for where it gets pasted.** It used padded
+  columns and indented commands, which line up in a terminal and in nothing else; composers
+  that strip blank lines on paste then collapsed it into one wall of text. Every line now
+  stands on its own, the two commands are one unindented line, and **assaio.dev** is named in
+  the post rather than only inside the install command — a reader who wants to know what
+  produced the numbers before running anything needs somewhere to go that is not a shell.
+
+
 ## [0.23.0] - 2026-08-17
 
 ### Added
@@ -2110,7 +2127,8 @@ exists to stop.
 - Cost honesty throughout: every `$` disclosed as an estimate at public
   pay-as-you-go API prices; unpriced models render an honest blank, never a fake `$0`.
 
-[Unreleased]: https://github.com/assaio/assaio/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/assaio/assaio/compare/v0.23.1...HEAD
+[0.23.1]: https://github.com/assaio/assaio/compare/v0.23.0...v0.23.1
 [0.23.0]: https://github.com/assaio/assaio/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/assaio/assaio/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/assaio/assaio/compare/v0.20.0...v0.21.0

--- a/internal/share/post.go
+++ b/internal/share/post.go
@@ -21,6 +21,10 @@ const Hashtag = "#ProofOfPrompt"
 const (
 	InstallCommand = "brew install assaio/tap/assaio-agent"
 	ShareCommand   = "assaio-agent share"
+	// Site is named in the post as well as on the artwork: a reader who wants to know what
+	// produced these numbers before running anything needs somewhere to go that is not a
+	// shell command.
+	Site = "assaio.dev"
 )
 
 // post writes the text that travels with the image. Two halves, because a post that only
@@ -32,17 +36,20 @@ const (
 func post(a *Assay, f *facts) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "My %s of AI, measured rather than guessed.\n\n", a.Window)
-	fmt.Fprintf(&b, "FAME  · %s\n", fameLine(f))
-	fmt.Fprintf(&b, "SHAME · %s\n", shameLine(a, f))
-	// The hook only earns a line here when it says something the two halves above did not.
-	// A scale or money hook repeats the fame line word for word, and a post that states its
-	// own headline twice reads as padding.
+	// Em dash rather than padded columns: the destination is a proportional font, where two
+	// spaces after FAME line up with nothing. Each line also stands on its own, because the
+	// composers that strip blank lines on paste turn a block layout into one wall of text.
+	fmt.Fprintf(&b, "FAME — %s\n", fameLine(f))
+	fmt.Fprintf(&b, "SHAME — %s\n\n", shameLine(a, f))
 	if a.Hook.Family != "scale" && a.Hook.Family != "money" && a.Hook.Line != "" {
-		fmt.Fprintf(&b, "\n%s\n", a.Hook.Line)
+		fmt.Fprintf(&b, "%s\n\n", a.Hook.Line)
 	}
-	b.WriteString("\nTwo commands and you have yours:\n")
-	fmt.Fprintf(&b, "  %s\n  %s\n", InstallCommand, ShareCommand)
-	b.WriteString("\nCounted locally. Nothing uploaded, no account, no repo names.\n\n")
+	b.WriteString("Counted locally from my own session logs: nothing uploaded, no account, no repository names.\n\n")
+	b.WriteString("Two commands and you have yours:\n")
+	// One line, unindented: leading spaces are stripped on paste, which left the second
+	// command hanging under a broken indent.
+	fmt.Fprintf(&b, "%s && %s\n\n", InstallCommand, ShareCommand)
+	fmt.Fprintf(&b, "%s\n\n", Site)
 	fmt.Fprintf(&b, "%s — what are your numbers of fame or shame? ;)", Hashtag)
 	return b.String()
 }

--- a/internal/share/share.html.tmpl
+++ b/internal/share/share.html.tmpl
@@ -239,7 +239,7 @@ function chrome(top) {
   lim.lines.forEach((l, i) => x.fillText(l, u(M), u(DH() - 50 + i * 22)));
 }
 
-const band = () => [170, DH() - 150];
+const band = () => [170, DH() - 186];
 const ease = p => 1 - Math.pow(1 - Math.min(1, Math.max(0, p)), 3);
 
 // SETTLE is the share of a scene its animation may use. Everything lands by then and the
@@ -387,38 +387,46 @@ function scRays(pRaw) {
 
 function scProfile(pRaw) {
   const p = q(pRaw); bg(); chrome('where the slack is');
-  const rowH = ts(112);
-  const line = fitText(A.Profile.Line || '', u(COLW), 2, ts(44), ts(28), 600);
   const [t, b] = band();
-  column([
-    { h: A.Profile.Axes.length * rowH, draw: y => {
-        A.Profile.Axes.forEach((ax, i) => {
-          const a = ease((p - i * .06) / .42); if (a <= 0) return;
-          const py = y + i * rowH;
-          x.save(); x.globalAlpha = a;
-          const col = ax.Reserve ? AMBER : FG;
-          font(ts(25), 400); const avw = mw(ax.Value);
-          atFit(ax.Left + ' — ' + ax.Right, M, py + ts(28), COLW - avw - ts(30), col, ts(29), 600);
-          at(ax.Value, 1080 - M, py + ts(28), ax.Reserve ? AMBER : DIM, ts(25), 400, 'right');
-          x.fillStyle = 'rgba(237,231,220,.16)';
-          x.fillRect(u(M), u(py + ts(50)), u(COLW), u(ts(9)));
-          x.fillStyle = ax.Reserve ? AMBER : '#3E8B79';
-          x.beginPath(); x.arc(u(M) + u(COLW) * ax.At * a, u(py + ts(54.5)), u(ts(16)), 0, 7); x.fill();
-          x.restore();
-        });
-      } },
-    { h: A.Profile.Line ? ts(34) + line.lines.length * line.size * 1.25 + ts(52) : 0, draw: y => {
-        if (!A.Profile.Line) return;
-        x.globalAlpha = ease((p - .55) / .4);
-        at(('reserve · ' + A.Profile.Title + ' · every card has one').toUpperCase(), M, y + ts(22), AMBER, ts(22), 500);
-        drawFit(line, M, y + ts(34) + line.size, AMBER, line.size * 1.25);
-        if (A.Profile.Caveats.length) {
-          const cav = fitText(A.Profile.Caveats[0], u(COLW), 2, ts(20), ts(15), 400);
-          cav.lines.forEach((l, i) => { font(cav.size, 400); x.fillStyle = FAINT; x.fillText(l, u(M), u(y + ts(34) + line.size + line.lines.length * line.size * 1.25 + ts(14) + i * cav.size * 1.35)); });
-        }
-        x.globalAlpha = 1;
-      } },
-  ], ts(56), t, b);
+  // fitColumn, not column: this is the densest scene, and on a square it is genuinely taller
+  // than the band. Centring an oversized stack starts it at the top and runs it out of the
+  // bottom -- which is how the caveat ended up printed over assaio.dev and the limit line.
+  fitColumn(k => {
+    const rowH = ts(112) * k;
+    const line = fitText(A.Profile.Line || '', u(COLW), 2, ts(44) * k, ts(26) * k, 600);
+    const cav = A.Profile.Caveats.length ? fitText(A.Profile.Caveats[0], u(COLW), 3, ts(19) * k, ts(13) * k, 400) : null;
+    const cavH = cav ? ts(16) * k + cav.lines.length * cav.size * 1.32 : 0;
+    return [
+      { h: A.Profile.Axes.length * rowH, draw: y => {
+          A.Profile.Axes.forEach((ax, i) => {
+            const a = ease((p - i * .06) / .42); if (a <= 0) return;
+            const py = y + i * rowH;
+            x.save(); x.globalAlpha = a;
+            const col = ax.Reserve ? AMBER : FG;
+            font(ts(25) * k, 400); const avw = mw(ax.Value);
+            atFit(ax.Left + ' — ' + ax.Right, M, py + ts(28) * k, COLW - avw - ts(30) * k, col, ts(29) * k, 600);
+            at(ax.Value, 1080 - M, py + ts(28) * k, ax.Reserve ? AMBER : DIM, ts(25) * k, 400, 'right');
+            x.fillStyle = 'rgba(237,231,220,.16)';
+            x.fillRect(u(M), u(py + ts(50) * k), u(COLW), u(ts(9) * k));
+            x.fillStyle = ax.Reserve ? AMBER : '#3E8B79';
+            x.beginPath(); x.arc(u(M) + u(COLW) * ax.At * a, u(py + ts(54.5) * k), u(ts(16) * k), 0, 7); x.fill();
+            x.restore();
+          });
+        } },
+      { h: A.Profile.Line ? ts(34) * k + line.lines.length * line.size * 1.25 + cavH : 0, draw: y => {
+          if (!A.Profile.Line) return;
+          x.globalAlpha = ease((p - .55) / .4);
+          at(('reserve · ' + A.Profile.Title + ' · every card has one').toUpperCase(), M, y + ts(22) * k, AMBER, ts(22) * k, 500);
+          drawFit(line, M, y + ts(34) * k + line.size, AMBER, line.size * 1.25);
+          if (cav) {
+            const top = y + ts(34) * k + line.lines.length * line.size * 1.25 + ts(16) * k;
+            font(cav.size, 400); x.fillStyle = FAINT;
+            cav.lines.forEach((l, i) => x.fillText(l, u(M), u(top + (i + 1) * cav.size * 1.32)));
+          }
+          x.globalAlpha = 1;
+        } },
+    ];
+  }, ts(56), t, b);
 }
 
 function scLedger(pRaw) {


### PR DESCRIPTION
Two defects found on the first real cards, both in what actually gets published.

**The profile frame printed its own caveat over the footer.** The block declared a fixed height allowance for a line that wraps, so on a 1:1 reel the axis disclaimer ran past the body band and landed on `assaio.dev`, the hashtag and the limit line — the three things that exist to qualify everything above them. The scene now sizes itself to the space it has, the way the poster already did, so a stack taller than its band shrinks instead of overflowing. Verified across all 7 scenes × 2 formats plus the poster: nothing occupies the strip between the band and the chrome.

**The post was formatted for a terminal.** Padded columns and indented commands line up in monospace and nowhere else, and composers that strip blank lines on paste collapsed the rest into one wall of text. Every line now stands on its own, the two commands are one unindented line, and **assaio.dev** is named in the post rather than only inside the install command.

Patch release `v0.23.1`: bug fixes only, no behaviour change beyond the fixed bugs.